### PR TITLE
Refactor converters with early returns

### DIFF
--- a/src/Devolutions.MacOS.Avalonia.Theme/Converters/SelectedIndexToPopupOffsetConverter.cs
+++ b/src/Devolutions.MacOS.Avalonia.Theme/Converters/SelectedIndexToPopupOffsetConverter.cs
@@ -7,17 +7,12 @@ public class SelectedIndexToPopupOffsetConverter : IMultiValueConverter
 {
   public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
   {
-    double offset = 0;
+    if (values is not [int index, int rowHeight, int initialBottomMargin, double maxDropDownHeight, int popupTrimHeight]
+        || index < 0) return 0D;
 
-    if (values is [int index, int rowHeight, int initialBottomMargin, double maxDropDownHeight, int popupTrimHeight] &&
-        index >= 0)
-    {
-      var effectivePopupHeight = maxDropDownHeight - popupTrimHeight;
-      var baseOffset = (index + 1) * -rowHeight - initialBottomMargin;
-      offset = -effectivePopupHeight < baseOffset ? baseOffset : -effectivePopupHeight;
-    }
-
-    return offset;
+    var effectivePopupHeight = maxDropDownHeight - popupTrimHeight;
+    double baseOffset = (index + 1) * -rowHeight - initialBottomMargin;
+    return -effectivePopupHeight < baseOffset ? baseOffset : -effectivePopupHeight;
   }
 
   public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Devolutions.MacOS.Avalonia.Theme/Converters/TotalWidthConverter.cs
+++ b/src/Devolutions.MacOS.Avalonia.Theme/Converters/TotalWidthConverter.cs
@@ -7,10 +7,9 @@ public class TotalWidthConverter : IMultiValueConverter
 {
   public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
   {
-    const double defaultWidth = 200;
-    if (values[0] is double width && values[1] is int sideMargin)
-      return width + 2 * sideMargin;
-    return defaultWidth;
+    if (values[0] is not double width || values[1] is not int sideMargin) return 200D;
+
+    return width + 2 * sideMargin;
   }
 
   public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
Just tidying up the code for the two converters used in `ComboBox.axaml`