### PR TITLE
Add source repo to package info (for nuget.org)

### DIFF
--- a/src/Devolutions.MacOS.Avalonia.Theme/Devolutions.MacOS.Avalonia.Theme.csproj
+++ b/src/Devolutions.MacOS.Avalonia.Theme/Devolutions.MacOS.Avalonia.Theme.csproj
@@ -4,6 +4,7 @@
         <Version>1.0.0.0</Version>
         <Company>Devolutions</Company>
         <Description>Devolutions Avalonia macOS Theme</Description>
+        <PackageProjectUrl>https://github.com/Devolutions/avalonia-themes</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
This should add a source link to the [package listing in the Nuget Gallery](https://www.nuget.org/packages/Devolutions.MacOS.Avalonia.Theme), so people can find the ReadMe with more info.