### PR TITLE
Fix disabled TextBox & polish focus border

### DIFF
--- a/src/Devolutions.MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
+++ b/src/Devolutions.MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
@@ -138,7 +138,7 @@
   <SolidColorBrush x:Key="TextBoxSelectionHighlightBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.3" />
   <SolidColorBrush x:Key="TextBoxBorderFocusBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.5" />
   <SolidColorBrush x:Key="TextBoxBackgroundDisabledHighBrush"
-                   Color="{StaticResource BackgroundColor}" Opacity="0.7" />
+                   Color="{StaticResource BackgroundColor}" Opacity="0.5" />
 
   <!-- DEVELOPMENT ONLY -->
   <SolidColorBrush x:Key="TestGreen" Color="Green" />

--- a/src/Devolutions.MacOS.Avalonia.Theme/Controls/TextBox.axaml
+++ b/src/Devolutions.MacOS.Avalonia.Theme/Controls/TextBox.axaml
@@ -81,7 +81,6 @@
     <!-- <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" /> TODO: make this a style? Class: rounded true/false -->
     <Setter Property="MinHeight" Value="27" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
-    <Setter Property="Padding" Value="3 3 3 2 " />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="Template">
@@ -89,10 +88,11 @@
         <DataValidationErrors>
           <Panel>
             <Border Name="FocusBorderElement"
-                    CornerRadius="{TemplateBinding CornerRadius}"
+                    CornerRadius="3"
                     Padding="3">
               <Border Name="PART_BorderElement"
                       BorderThickness="1"
+                      BorderBrush="Transparent"
                       BoxShadow="{DynamicResource ButtonBorderBoxShadow}"
                       Background="{TemplateBinding Background}">
                 <Grid ColumnDefinitions="Auto,*,Auto">
@@ -107,7 +107,7 @@
                   </ContentPresenter>
                   <DockPanel x:Name="PART_InnerDockPanel"
                              Grid.Column="1"
-                             Margin="{TemplateBinding Padding}">
+                             Margin="2 2 3 1 ">
                     <ScrollViewer Name="PART_ScrollViewer"
                                   HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                                   VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
@@ -189,6 +189,9 @@
 
     <!-- Focused State -->
     <Style Selector="^:focus">
+      <Style Selector="^ /template/ DockPanel#PART_InnerDockPanel">
+        <Setter Property="Margin" Value="2 1 3 0 " />
+      </Style>
       <Style Selector="^ /template/ Border#FocusBorderElement">
         <Setter Property="Background" Value="{DynamicResource TextBoxBorderFocusBrush}" />
       </Style>

--- a/src/Devolutions.MacOS.Avalonia.Theme/Controls/TextBox.axaml
+++ b/src/Devolutions.MacOS.Avalonia.Theme/Controls/TextBox.axaml
@@ -88,13 +88,13 @@
       <ControlTemplate>
         <DataValidationErrors>
           <Panel>
-            <Border Name="PART_BorderElement"
-                    Background="{TemplateBinding Background}"
+            <Border Name="FocusBorderElement"
                     CornerRadius="{TemplateBinding CornerRadius}"
                     Padding="3">
-              <Border Name="InnerBorderElement"
+              <Border Name="PART_BorderElement"
+                      BorderThickness="1"
                       BoxShadow="{DynamicResource ButtonBorderBoxShadow}"
-                      Background="{DynamicResource ControlBackgroundHighBrush}">
+                      Background="{TemplateBinding Background}">
                 <Grid ColumnDefinitions="Auto,*,Auto">
                   <ContentPresenter Name="PrefixContent"
                                     Grid.Column="0"
@@ -189,7 +189,7 @@
 
     <!-- Focused State -->
     <Style Selector="^:focus">
-      <Style Selector="^ /template/ Border#PART_BorderElement">
+      <Style Selector="^ /template/ Border#FocusBorderElement">
         <Setter Property="Background" Value="{DynamicResource TextBoxBorderFocusBrush}" />
       </Style>
     </Style>


### PR DESCRIPTION
The disabled background colour (white @ opacity 70%) didn't come through, because the box used to create the system-colour border, was set to be white when not in focus.

I also set the opacity to 50% now (despite [Apple Design Resources](https://www.figma.com/design/E0jwRwSdmCNREfsFJxRKyy/Apple-Design-Resources---macOS-(Community)?node-id=121-12220&t=OT2AzIQTqrAGJkPm-0) specifying 70%. On a light background it just seems to be very difficult to distinguish from an enabled TextBox with just a placeholder.

![image](https://github.com/user-attachments/assets/0eda5e7e-f4a8-4a18-a2af-d30febd9ad3d)

Some tweaks to the focus border. (I tried to get away from using a background to achieve the border, but couldn't get rid of a 1px gray line on the inside when using BorderBrush)

![image](https://github.com/user-attachments/assets/d0f5823c-2d00-41fc-b82b-305b1d0aa9bd)
![image](https://github.com/user-attachments/assets/abd7c525-a3a6-496e-b3d7-eca307353a23)



