### PR TITLE
Fix prefix/suffix affecting TextBox height

### DIFF
--- a/src/Devolutions.MacOS.Avalonia.Theme/Controls/TextBox.axaml
+++ b/src/Devolutions.MacOS.Avalonia.Theme/Controls/TextBox.axaml
@@ -99,7 +99,7 @@
                   <ContentPresenter Name="PrefixContent"
                                     Grid.Column="0"
                                     Content="{TemplateBinding InnerLeftContent}"
-                                    Padding="3 3 3 2">
+                                    Padding="3 2 3 1">
                     <ContentPresenter.IsVisible>
                       <Binding RelativeSource="{RelativeSource Self}" Path="Content"
                                Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
@@ -163,7 +163,7 @@
                   </DockPanel>
                   <ContentPresenter Name="SuffixContent"
                                     Grid.Column="2"
-                                    Padding="3 3 3 2"
+                                    Padding="3 2 3 1"
                                     Content="{TemplateBinding InnerRightContent}">
                     <ContentPresenter.IsVisible>
                       <Binding RelativeSource="{RelativeSource Self}" Path="Content"


### PR DESCRIPTION
Fixed the issue where TextBoxes with a given prefix or suffix to the user input displayed a little bit higher than plain ones. 

![image](https://github.com/user-attachments/assets/9643717d-5c61-4d83-b31a-ac51bf3e78fb)
 