### PR TITLE
Fix TextBox Clear button

### DIFF
--- a/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
+++ b/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
@@ -180,7 +180,7 @@
   <SolidColorBrush x:Key="PopupBackgroundBrush" Color="{DynamicResource PopupBackgroundColor}" />
 
   <!-- TextBox Resources -->
-  <SolidColorBrush x:Key="TextBoxClearBackgroundBrush" Color="{StaticResource TextBoxClearBackgroundColor}" />
+  <SolidColorBrush x:Key="TextBoxClearBackgroundBrush" Color="{DynamicResource TextBoxClearBackgroundColor}" />
   <SolidColorBrush x:Key="TextBoxSelectionHighlightBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.3" />
   <SolidColorBrush x:Key="TextBoxBorderFocusBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.5" />
   <SolidColorBrush x:Key="TextBoxBackgroundDisabledHighBrush"


### PR DESCRIPTION
This fixes bug I introduced when adding dark mode support (#30), leading to a run-time error when accessing a TextBox with Clear button, because its bg colour was not available. 