### PR TITLE
Add Theme prefix to custom classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ In your App.axaml, replace the existing theme (e.g. `<FluentTheme />` or `<Simpl
 || <h3>TransitioningContentControl</h3> ||
 ||||
 |✅ | <h3>TreeView</h3> <h4>TreeViewItem<h4> ||
-|| <img src="https://github.com/user-attachments/assets/0f1981ae-d001-49f9-8ee3-fda47ec2a461" alt="TabControl demo" max-width="515"> | Striped background currently cannot be rendered with rounded corners & breaks when default TreeViewItem height is altered (see comment in ThemeResources.axaml)|
+|| <img src="https://github.com/user-attachments/assets/0f1981ae-d001-49f9-8ee3-fda47ec2a461" alt="TabControl demo" max-width="515"> | Use `Classes="MacOS_Theme_AlternatingRowColor" to achieve striped background.  (Cannot currently be rendered with rounded corners & breaks when default TreeViewItem height is altered (see comment in ThemeResources.axaml))|
 || <h3>Window</h3> ||
 ||||
 || <h3>WindowNotificationManager</h3> ||

--- a/samples/SampleApp/DemoPages/MenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuDemo.axaml
@@ -73,7 +73,8 @@
       <Border Background="Gainsboro">
         <DockPanel>
           <DockPanel DockPanel.Dock="Top">
-            <Menu DockPanel.Dock="Left" VerticalAlignment="Top" Classes=" LabelBelowIcon OnGray Icons25">
+            <Menu DockPanel.Dock="Left" VerticalAlignment="Top"
+                  Classes=" MacOS_Theme_MenuLabelBelowIcon OnGray Icons25">
               <MenuItem Header="Copy name">
                 <MenuItem.Icon>
                   <Svg Path="/Assets/CopyName.svg" />
@@ -93,7 +94,7 @@
               </MenuItem>
             </Menu>
             <Menu DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right"
-                  Classes="LabelBelowIcon Icons15">
+                  Classes="MacOS_Theme_MenuLabelBelowIcon Icons15">
               <MenuItem Header="Group" IsEnabled="False">
                 <MenuItem.Icon>
                   <Svg Path="/Assets/EnableUser.svg" />
@@ -117,7 +118,7 @@
           <Menu Name="BottomIconMenu"
                 DockPanel.Dock="Bottom"
                 VerticalAlignment="Bottom"
-                Classes="OpenAbove IconOnly LabelBelowIcon">
+                Classes="MacOS_Theme_MenuOpensAbove MacOS_Theme_MenuItemIconOnly MacOS_Theme_MenuLabelBelowIcon">
             <MenuItem Header="Selected" IsSelected="True">
               <MenuItem.Icon>
                 <Svg Path="/Assets/Add.svg" />

--- a/samples/SampleApp/DemoPages/TreeViewDemo.axaml
+++ b/samples/SampleApp/DemoPages/TreeViewDemo.axaml
@@ -86,7 +86,7 @@
     <!-- With alternating row colour & scrolling -->
     <StackPanel Spacing="20">
 
-      <TreeView Width="150" Height="160" Classes="AlternatingRowColor" BorderBrush="LightGray" BorderThickness="1">
+      <TreeView Width="150" Height="160" Classes="MacOS_Theme_AlternatingRowColor" BorderBrush="LightGray" BorderThickness="1">
         <TreeViewItem Header="Level 1.1">
           <TreeViewItem Header="Level 2.1" />
           <TreeViewItem Header="Level 2.2" />
@@ -108,7 +108,7 @@
       </TreeView>
       <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center">
         For alternating row colour use: <LineBreak />
-        <TextBlock Classes="code" FontSize="13" Text="Classes=&quot;AlternatingRowColor&quot;" />
+        <TextBlock Classes="code" FontSize="13" Text="Classes=&quot;MacOS_Theme_AlternatingRowColor&quot;" />
       </TextBlock>
     </StackPanel>
   </StackPanel>

--- a/src/MacOS.Avalonia.Theme/Accents/Styles.axaml
+++ b/src/MacOS.Avalonia.Theme/Accents/Styles.axaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-  <Style Selector="Menu.OpenAbove > MenuItem > Border > Panel > Popup">
+  <Style Selector="Menu.MacOS_Theme_MenuOpensAbove > MenuItem > Border > Panel > Popup">
     <Setter Property="Placement" Value="TopEdgeAlignedLeft" />
     <Setter Property="VerticalOffset" Value="{DynamicResource MenuPopupAboveVerticalOffset}" />
     <Style Selector="^ Border">
@@ -22,4 +22,9 @@
       </Setter.Value>
     </Setter>
   </Style>
+
+  <!-- Custom Classes used as ConverterParameters in Template styles - declared here to make them available to the IDE's parser to avoid false error highlighting -->
+  <Style Selector=".MacOS_Theme_MenuLabelBelowIcon" />
+  <Style Selector=".MacOS_Theme_MenuItemIconOnly" />
+
 </Styles>

--- a/src/MacOS.Avalonia.Theme/Controls/Menu.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/Menu.axaml
@@ -3,7 +3,8 @@
 
   <Design.PreviewWith>
     <DockPanel Height="200">
-      <Menu DockPanel.Dock="Top" VerticalAlignment="Top" Classes="IconOnly LabelBelowIcon">
+      <Menu DockPanel.Dock="Top" VerticalAlignment="Top"
+            Classes="MacOS_Theme_MenuItemIconOnly MacOS_Theme_MenuLabelBelowIcon">
         <MenuItem Header="Add">
           <MenuItem.Icon>
             <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
@@ -22,7 +23,8 @@
           </MenuItem.Icon>
         </MenuItem>
       </Menu>
-      <Menu DockPanel.Dock="Bottom" VerticalAlignment="Bottom" Classes="OpenAbove LabelBelowIcon">
+      <Menu DockPanel.Dock="Bottom" VerticalAlignment="Bottom"
+            Classes="MacOS_Theme_MenuOpensAbove MacOS_Theme_MenuLabelBelowIcon">
         <MenuItem Header="_Standard">
           <MenuItem.Icon>
             <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
@@ -49,7 +51,8 @@
   <ControlTheme x:Key="FluentTopLevelMenuItem" TargetType="MenuItem">
     <Setter Property="FontSize">
       <Setter.Value>
-        <MultiBinding Converter="{StaticResource ClassToChoiceConverter}" ConverterParameter="LabelBelowIcon">
+        <MultiBinding Converter="{StaticResource ClassToChoiceConverter}"
+                      ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
           <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
           <Binding Source="{StaticResource MenuHeaderFontSizeSmall}" />
           <Binding Source="{StaticResource ControlFontSize}" />
@@ -72,7 +75,8 @@
           <Panel>
             <StackPanel>
               <StackPanel.Orientation>
-                <MultiBinding Converter="{StaticResource ClassToChoiceConverter}" ConverterParameter="LabelBelowIcon">
+                <MultiBinding Converter="{StaticResource ClassToChoiceConverter}"
+                              ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
                   <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
                   <Binding Source="{x:Static Orientation.Vertical}" />
                   <Binding Source="{x:Static Orientation.Horizontal}" />
@@ -86,7 +90,8 @@
                 <ContentPresenter Name="PART_IconPresenter"
                                   Content="{TemplateBinding Icon}">
                   <ToolTip.ServiceEnabled>
-                    <MultiBinding Converter="{StaticResource ClassToChoiceConverter}" ConverterParameter="IconOnly">
+                    <MultiBinding Converter="{StaticResource ClassToChoiceConverter}"
+                                  ConverterParameter="MacOS_Theme_MenuItemIconOnly">
                       <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
                       <Binding Source="{x:True}" />
                       <Binding Source="{x:False}" />
@@ -110,7 +115,7 @@
                       </Path.RenderTransform>
                       <Path.IsVisible>
                         <MultiBinding Converter="{StaticResource ClassToChoiceConverter}"
-                                      ConverterParameter="LabelBelowIcon">
+                                      ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
                           <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
                           <Binding Source="{x:True}" />
                           <Binding Source="{x:False}" />
@@ -131,14 +136,16 @@
                                 TextAlignment="Center"
                                 RecognizesAccessKey="True">
                 <ContentPresenter.IsVisible>
-                  <MultiBinding Converter="{StaticResource ClassToChoiceConverter}" ConverterParameter="IconOnly">
+                  <MultiBinding Converter="{StaticResource ClassToChoiceConverter}"
+                                ConverterParameter="MacOS_Theme_MenuItemIconOnly">
                     <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
                     <Binding Source="{x:False}" />
                     <Binding Source="{x:True}" />
                   </MultiBinding>
                 </ContentPresenter.IsVisible>
                 <ContentPresenter.Margin>
-                  <MultiBinding Converter="{StaticResource ClassToChoiceConverter}" ConverterParameter="LabelBelowIcon">
+                  <MultiBinding Converter="{StaticResource ClassToChoiceConverter}"
+                                ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
                     <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
                     <Binding Source="{StaticResource MenuTextBelowIconMargin }" />
                   </MultiBinding>

--- a/src/MacOS.Avalonia.Theme/Controls/TreeView.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/TreeView.axaml
@@ -44,7 +44,7 @@
       </ControlTemplate>
     </Setter>
 
-    <Style Selector="^.AlternatingRowColor /template/ Panel#BackgroundPanel">
+    <Style Selector="^.MacOS_Theme_AlternatingRowColor /template/ Panel#BackgroundPanel">
       <Setter Property="Background" Value="{DynamicResource StripedBackgroundBrush}" />
     </Style>
   </ControlTheme>


### PR DESCRIPTION
Just renaming the custom classes to make it clear that they belong to the MacOS theme and have no effect otherwise.