### PR TITLE
Tidy up after move to `<Svg>` instead of `<Image>`

### DIFF
--- a/samples/SampleApp/DemoPages/DataGridDemo.axaml
+++ b/samples/SampleApp/DemoPages/DataGridDemo.axaml
@@ -23,7 +23,7 @@
       <DataGridTemplateColumn Header="">
         <DataGridTemplateColumn.CellTemplate>
           <DataTemplate>
-            <Image Source="{StaticResource ComputerIcon}" Width="20" Height="20" />
+            <Svg Path="/Assets/Computer.svg" Width="20" Height="20" Css=".st0 {fill: #3B86EA}" />
           </DataTemplate>
         </DataGridTemplateColumn.CellTemplate>
       </DataGridTemplateColumn>

--- a/samples/SampleApp/DemoPages/MenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuDemo.axaml
@@ -7,10 +7,10 @@
 
   <UserControl.Styles>
     <Style Selector="Menu.OnGray Svg:not(:disabled)">
-      <Setter Property="(Svg.Css)" Value=".st0 {fill : #3E6CB0; }" />
+      <Setter Property="Css" Value=".st0 {fill : #3E6CB0; }" />
     </Style>
     <Style Selector="Menu.OnWhite Svg:not(:disabled)">
-      <Setter Property="(Svg.Css)" Value=".st0 {fill : #3B86EA; }" />
+      <Setter Property="Css" Value=".st0 {fill : #3B86EA; }" />
     </Style>
     <Style Selector="Menu.Icons25 Svg">
       <Setter Property="Width" Value="25" />

--- a/samples/SampleApp/DemoPages/TreeViewDemo.axaml
+++ b/samples/SampleApp/DemoPages/TreeViewDemo.axaml
@@ -5,6 +5,13 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.TreeViewDemo">
 
+  <UserControl.Styles>
+    <Style Selector="TreeViewItem Svg">
+      <Setter Property="Css" Value=".st0 {fill: #3B86EA}" />
+      <Setter Property="Width" Value="16" />
+      <Setter Property="Height" Value="16" />
+    </Style>
+  </UserControl.Styles>
 
   <StackPanel Orientation="Horizontal" Spacing="30" VerticalAlignment="Top">
     <TreeView Width="150">
@@ -27,21 +34,21 @@
       <TreeViewItem IsExpanded="True">
         <TreeViewItem.Header>
           <StackPanel Orientation="Horizontal" Spacing="5">
-            <Image Source="{StaticResource FolderIcon}" Width="16" Height="16" />
+            <Svg Path="/Assets/Folder.svg" />
             <TextBlock>Level 1.1</TextBlock>
           </StackPanel>
         </TreeViewItem.Header>
         <TreeViewItem IsExpanded="True">
           <TreeViewItem.Header>
             <StackPanel Orientation="Horizontal" Spacing="5">
-              <Image Source="{StaticResource FolderIcon}" Width="16" Height="16" />
+              <Svg Path="/Assets/Folder.svg" />
               <TextBlock>Level 2.1</TextBlock>
             </StackPanel>
           </TreeViewItem.Header>
           <TreeViewItem>
             <TreeViewItem.Header>
               <StackPanel Orientation="Horizontal" Spacing="5">
-                <Image Source="{StaticResource FolderIcon}" Width="16" Height="16" />
+                <Svg Path="/Assets/Folder.svg" />
                 <TextBlock>Level 3.1</TextBlock>
               </StackPanel>
             </TreeViewItem.Header>
@@ -49,7 +56,7 @@
           <TreeViewItem>
             <TreeViewItem.Header>
               <StackPanel Orientation="Horizontal" Spacing="5">
-                <Image Source="{StaticResource FolderIcon}" Width="16" Height="16" />
+                <Svg Path="/Assets/Folder.svg" />
                 <TextBlock>Level 3.2</TextBlock>
               </StackPanel>
             </TreeViewItem.Header>
@@ -57,14 +64,14 @@
           <TreeViewItem>
             <TreeViewItem.Header>
               <StackPanel Orientation="Horizontal" Spacing="5">
-                <Image Source="{StaticResource FolderIcon}" Width="16" Height="16" />
+                <Svg Path="/Assets/Folder.svg" />
                 <TextBlock>Level 3.3</TextBlock>
               </StackPanel>
             </TreeViewItem.Header>
             <TreeViewItem>
               <TreeViewItem.Header>
                 <StackPanel Orientation="Horizontal" Spacing="5">
-                  <Image Source="{StaticResource FolderIcon}" Width="16" Height="16" />
+                  <Svg Path="/Assets/Folder.svg" />
                   <TextBlock>Level 4.1</TextBlock>
                 </StackPanel>
               </TreeViewItem.Header>
@@ -72,7 +79,7 @@
             <TreeViewItem>
               <TreeViewItem.Header>
                 <StackPanel Orientation="Horizontal" Spacing="5">
-                  <Image Source="{StaticResource FolderIcon}" Width="16" Height="16" />
+                  <Svg Path="/Assets/Folder.svg" />
                   <TextBlock>Level 4.2</TextBlock>
                 </StackPanel>
               </TreeViewItem.Header>
@@ -86,7 +93,8 @@
     <!-- With alternating row colour & scrolling -->
     <StackPanel Spacing="20">
 
-      <TreeView Width="150" Height="160" Classes="MacOS_Theme_AlternatingRowColor" BorderBrush="LightGray" BorderThickness="1">
+      <TreeView Width="150" Height="160" Classes="MacOS_Theme_AlternatingRowColor" BorderBrush="LightGray"
+                BorderThickness="1">
         <TreeViewItem Header="Level 1.1">
           <TreeViewItem Header="Level 2.1" />
           <TreeViewItem Header="Level 2.2" />

--- a/samples/SampleApp/MainWindow.axaml
+++ b/samples/SampleApp/MainWindow.axaml
@@ -62,10 +62,7 @@
     <TabItem>
       <TabItem.Header>
         <StackPanel Orientation="Horizontal">
-          <!-- TODO: Find a way to use SVGs as SVGs ... i.e. allow currentColor to be set etc. -->
-          <!-- <svg:Svg Path="/Assets/Padlock.svg" Width="16" Height="16" Margin="0,0,5,0" /> -->
-          <!-- <Image Source="{SvgImage /Assets/Padlock.svg}"/> -->
-          <Image Source="{StaticResource PadlockIcon}" Height="16" Width="16" Margin="0 -3 3 0" />
+          <Svg Path="/Assets/Padlock.svg" Height="16" Width="16" Margin="-2 -2 2 0" Css=".st0 {fill : #3E6CB0; }" />
           <TextBlock Text="Experiments" />
         </StackPanel>
       </TabItem.Header>

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -20,9 +20,6 @@
     <ItemGroup>
         <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.0.2"/>
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
-        <!--        TODO: Check if you need these three ...  -->
-        <PackageReference Include="Svg.SourceGenerator.Skia" Version="2.0.0.4"/>
-        <PackageReference Include="Avalonia.Controls.Skia" Version="11.2.0.2"/>
         <!-- <PackageReference Include="MacOS.Avalonia.Theme" Version="2024.12.4" /> -->
     </ItemGroup>
 

--- a/src/MacOS.Avalonia.Theme/Accents/Styles.axaml
+++ b/src/MacOS.Avalonia.Theme/Accents/Styles.axaml
@@ -15,7 +15,7 @@
   </Style>
 
   <Style Selector="Svg:disabled">
-    <Setter Property="(Svg.Css)">
+    <Setter Property="Css">
       <Setter.Value>
         <Binding Source="{StaticResource SvgIconDisabledColorBrush}"
                  Converter="{StaticResource ColorToCssFillConverter}" />

--- a/src/MacOS.Avalonia.Theme/Controls/Menu.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/Menu.axaml
@@ -185,7 +185,7 @@
 
     <!-- Not working -> handled in Styles.axaml -->
     <!-- <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter Svg"> -->
-    <!--   <Setter Property="(Svg.Css)" Value=".st0 {fill : #9500C3; }" /> -->
+    <!--   <Setter Property="Css" Value=".st0 {fill : #9500C3; }" /> -->
     <!-- </Style> -->
     <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter:empty">
       <Setter Property="IsVisible" Value="False" />
@@ -212,7 +212,7 @@
       </Style>
       <!-- Not working -> handled in Styles.axaml -->
       <!-- <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter Svg:disabled"> -->
-      <!--   <Setter Property="(Svg.Css)" Value=".st0 {fill : #dddddd; }" /> -->
+      <!--   <Setter Property="Css" Value=".st0 {fill : #dddddd; }" /> -->
       <!-- </Style> -->
     </Style>
 


### PR DESCRIPTION
- Fixing some icons that broke when I started using `<Svg>` to place icons.
- Removing unintuitive use of property `(Svg.Css)` - just `Css` seems to be working fine now ... 🙃
- Removing redundant SVG packages 