### PR TITLE
Make GridSplitter work in horizontal direction too

### DIFF
--- a/samples/SampleApp/DemoPages/GridSplitterDemo.axaml
+++ b/samples/SampleApp/DemoPages/GridSplitterDemo.axaml
@@ -12,8 +12,14 @@
           <Border Height="2000" />
         </ScrollViewer>
       </Border>
-      <GridSplitter Grid.Column="1" />
-      <Border Grid.Column="2" Background="{DynamicResource BackgroundColor}" />
+      <GridSplitter Grid.Column="1" ResizeDirection="Columns" />
+      <Border Grid.Column="2" Background="{DynamicResource BackgroundColor}">
+        <Grid RowDefinitions="*, 1, 100">
+          <Border Grid.Row="0" Background="{DynamicResource BackgroundColor}" />
+          <GridSplitter Grid.Row="1" ResizeDirection="Rows" />
+          <Border Grid.Row="2" Background="{DynamicResource LayoutBackgroundLowBrush}" />
+        </Grid>
+      </Border>
     </Grid>
   </Border>
 

--- a/src/MacOS.Avalonia.Theme/Controls/GridSplitter.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/GridSplitter.axaml
@@ -1,10 +1,32 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=System.Runtime">
+
+  <Design.PreviewWith>
+    <Border Height="400" BorderBrush="{DynamicResource LayoutBorderHighBrush}" BorderThickness="1" Margin="5">
+      <Grid ColumnDefinitions="50, 1, 250">
+        <Border Grid.Column="0" Background="{DynamicResource BackgroundColor}">
+          <ScrollViewer>
+            <Border Height="2000" />
+          </ScrollViewer>
+        </Border>
+        <GridSplitter Grid.Column="1" ResizeDirection="Columns" />
+        <Border Grid.Column="2" Background="{DynamicResource BackgroundColor}">
+          <Grid RowDefinitions="30, 1, *">
+            <Border Grid.Row="0" Background="{DynamicResource BackgroundColor}" />
+            <GridSplitter Grid.Row="1" ResizeDirection="Rows" />
+            <Border Grid.Row="2" Background="{DynamicResource BackgroundColor}" />
+          </Grid>
+        </Border>
+      </Grid>
+    </Border>
+  </Design.PreviewWith>
+
 
   <ControlTheme x:Key="{x:Type GridSplitter}" TargetType="GridSplitter">
     <Setter Property="Focusable" Value="True" />
-    <Setter Property="MinWidth" Value="6" />
-    <Setter Property="MinHeight" Value="6" />
+    <Setter Property="MinWidth" Value="10" />
+    <Setter Property="MinHeight" Value="10" />
     <Setter Property="Background" Value="{DynamicResource GridSplitterLineColor}" />
     <Setter Property="PreviewContent">
       <Template>
@@ -17,10 +39,20 @@
                 BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="{TemplateBinding CornerRadius}"
                 Background="Transparent">
-          <Rectangle Fill="{TemplateBinding Background}" Width="1" HorizontalAlignment="Center"
+          <Rectangle Name="VisualLineMarker"
+                     Fill="{TemplateBinding Background}"
+                     Width="1"
+                     Height="{x:Static sys:Double.NaN}"
+                     HorizontalAlignment="Center"
                      VerticalAlignment="Stretch" />
         </Border>
       </ControlTemplate>
     </Setter>
+    <Style Selector="^[ResizeDirection=Rows] /template/ Rectangle#VisualLineMarker">
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+      <Setter Property="Width" Value="{x:Static sys:Double.NaN}" />
+      <Setter Property="Height" Value="1" />
+    </Style>
   </ControlTheme>
 </ResourceDictionary>


### PR DESCRIPTION
Fix the `GridSplitter` to show the thin divider line correctly when used as horizontal divider