### PR TITLE
Fix scrollbar background leaking into the viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ In your App.axaml, replace the existing theme (e.g. `<FluentTheme />` or `<Simpl
 || <h3>RepeatButton</h3> ||
 ||||
 |✅ | <h3>ScrollViewer</h3> <h3>ScrollBar</h3> ||
-|| Default:<br /><img max-width="415" alt="ScrollViewer - default" src="https://github.com/user-attachments/assets/71bbd1ea-c2ec-44b6-a943-6f51dd0a3e65" /><br />`AllowAutoHide="False"`:<br /><img max-width="418" alt="ScrollViewer - AllowAutoHide false" src="https://github.com/user-attachments/assets/60116d7d-90a0-49b2-9736-f9d7715e89e8" /><br />`BorderThickness="0" Background="Transparent"`:<br /><img max-width="414" alt="ScrollViewer - transparent" src="https://github.com/user-attachments/assets/72736b28-7890-49e2-b566-5e31a0b6b994" /> ||
+|| Default:<br /><img max-width="415" alt="ScrollViewer - default" src="https://github.com/user-attachments/assets/71bbd1ea-c2ec-44b6-a943-6f51dd0a3e65" /><br />`AllowAutoHide="False"`:<br /><img max-width="418" alt="ScrollViewer - AllowAutoHide false" src="https://github.com/user-attachments/assets/60116d7d-90a0-49b2-9736-f9d7715e89e8" /> | Note that even with `AllowAutoHide="True"` the scrollbars won't completely hide. This is intentional, since scrolling events will not trigger a 'show' (only moving the pointer directly over the track area will) - so completely hiding would be confusing. <br /><br />Mousing over one of the track areas will make the thumb bar grow wider and darker and the track appears. To suppress this behaviour (e.g. on images) use `Classes="MacOS_TransparentTrack"` |
 || <h3>SelectableTextBlock</h3> ||
 ||||
 |✅ | <h3>Separator</h3> ||

--- a/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
+++ b/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
@@ -8,9 +8,10 @@
     <StackPanel>
       <Grid ColumnDefinitions="Auto, 420, 420" RowDefinitions="Auto, 320, 320">
         <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Center">Default</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="2" HorizontalAlignment="Center" Classes="code">BorderThickness="0" Background="Transparent"</TextBlock>
+        <TextBlock Grid.Row="0" Grid.Column="2" HorizontalAlignment="Center" Classes="code">Classes="MacOS_TransparentTrack"</TextBlock>
         <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">Default</TextBlock>
-        <Border Grid.Row="1" Grid.Column="1" BorderBrush="#dddddd" BorderThickness="1" Width="400" Height="300">
+        <Border Grid.Row="1" Grid.Column="1" Background="White" BorderBrush="#dddddd" BorderThickness="1" Width="400"
+                Height="300">
           <ScrollViewer HorizontalScrollBarVisibility="Auto" Padding="5 ">
             <StackPanel Background="white">
               <TextBlock>drwxr-xr-x  26 jdoe  staff     832 28 Jan 14:27 .</TextBlock>
@@ -42,11 +43,13 @@
             </StackPanel>
           </ScrollViewer>
         </Border>
-        <ScrollViewer Grid.Row="1" Grid.Column="2" Width="400" Height="300" HorizontalScrollBarVisibility="Auto"
-                      BorderThickness="0" Background="Transparent">
-          <Image Width="800" Height="600"
-                 Source="avares://SampleApp/Assets/SampleImage.jpg" />
-        </ScrollViewer>
+
+        <Border Grid.Row="1" Grid.Column="2" BorderBrush="#dddddd" BorderThickness="1" Width="400" Height="300">
+          <ScrollViewer HorizontalScrollBarVisibility="Auto" Classes="MacOS_TransparentTrack">
+            <Image Width="800" Height="600"
+                   Source="avares://SampleApp/Assets/SampleImage.jpg" />
+          </ScrollViewer>
+        </Border>
 
         <TextBlock Grid.Row="2" Grid.Column="0" HorizontalAlignment="Center" Classes="code" VerticalAlignment="Center">AllowAutoHide="False"</TextBlock>
         <Border Grid.Row="2" Grid.Column="1" BorderBrush="#dddddd" BorderThickness="1" Width="400" Height="300">
@@ -81,12 +84,13 @@
             </StackPanel>
           </ScrollViewer>
         </Border>
-        <ScrollViewer Grid.Row="2" Grid.Column="2" Width="400" Height="300" HorizontalScrollBarVisibility="Auto"
-                      AllowAutoHide="False"
-                      BorderThickness="0" Background="Transparent">
-          <Image Width="800" Height="600"
-                 Source="avares://SampleApp/Assets/SampleImage.jpg" />
-        </ScrollViewer>
+
+        <Border Grid.Row="2" Grid.Column="2" BorderBrush="#dddddd" BorderThickness="1" Width="400" Height="300">
+          <ScrollViewer HorizontalScrollBarVisibility="Auto" Classes="MacOS_TransparentTrack" AllowAutoHide="False">
+            <Image Width="800" Height="600"
+                   Source="avares://SampleApp/Assets/SampleImage.jpg" />
+          </ScrollViewer>
+        </Border>
       </Grid>
       <TextBlock TextWrapping="Wrap">
         <Bold>Note:</Bold> MacOS hides scrollbars completely (depending on user settings), but they re-appear on scroll events.

--- a/samples/SampleApp/DemoPages/TreeViewDemo.axaml
+++ b/samples/SampleApp/DemoPages/TreeViewDemo.axaml
@@ -93,7 +93,9 @@
     <!-- With alternating row colour & scrolling -->
     <StackPanel Spacing="20">
 
-      <TreeView Width="150" Height="160" Classes="MacOS_Theme_AlternatingRowColor" BorderBrush="LightGray"
+      <TreeView Width="150" Height="160" Classes="MacOS_Theme_AlternatingRowColor"
+                Background="White"
+                BorderBrush="LightGray"
                 BorderThickness="1">
         <TreeViewItem Header="Level 1.1">
           <TreeViewItem Header="Level 2.1" />

--- a/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
+++ b/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
@@ -255,6 +255,7 @@
   <x:Double x:Key="ScrollBarMinLength">10</x:Double>
   <SolidColorBrush x:Key="ScrollBarTrackBrush" Color="{DynamicResource ScrollBarTrackColor}" />
   <SolidColorBrush x:Key="ScrollBarTrackBorderBrush" Color="{DynamicResource ScrollBarTrackBorderColor}" />
+  <Thickness x:Key="ScrollBarTrackBorderThickness">1</Thickness>
   <Thickness x:Key="ScrollBarSeparatorBorderFactors">0 0 1 1</Thickness>
   <Thickness x:Key="ScrollBarTrackHorizontalBorderFactors">0 1 0 1</Thickness>
   <Thickness x:Key="ScrollBarTrackVerticalBorderFactors">1 0 1 0</Thickness>

--- a/src/MacOS.Avalonia.Theme/Controls/ComboBox.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/ComboBox.axaml
@@ -166,8 +166,7 @@
                     Padding="{DynamicResource PopupPadding}"
                     BoxShadow="{DynamicResource PopupShadow}">
               <ScrollViewer
-                BorderThickness="0"
-                Background="Transparent"
+                Classes="MacOS_TransparentTrack"
                 HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                 VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                 IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">

--- a/src/MacOS.Avalonia.Theme/Controls/DataGrid.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/DataGrid.axaml
@@ -533,9 +533,6 @@
     <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
     <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
-    <Setter Property="ScrollBar.Background" Value="{DynamicResource ScrollBarTrackBrush}" />
-    <Setter Property="ScrollBar.BorderBrush" Value="{DynamicResource ScrollBarTrackBorderBrush}" />
-    <Setter Property="ScrollBar.BorderThickness" Value="1" />
     <Setter Property="ScrollBar.AllowAutoHide" Value="False" />
     <Setter Property="DropLocationIndicatorTemplate">
       <Template>
@@ -577,19 +574,22 @@
             <Border Name="PART_ScrollBarsSeparator"
                     Grid.Row="2"
                     Grid.Column="2"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness, 
-                      Converter={StaticResource ThicknessToSelectiveThicknessConverter}, 
-                      ConverterParameter={StaticResource ScrollBarSeparatorBorderFactors}}"
-                    IsVisible="{TemplateBinding ScrollBar.AllowAutoHide, Converter={x:Static BoolConverters.Not}}" />
+                    Background="{DynamicResource ScrollBarTrackBrush}"
+                    BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                    IsVisible="{TemplateBinding ScrollBar.AllowAutoHide, Converter={x:Static BoolConverters.Not}}">
+              <Border.BorderThickness>
+                <Binding Source="{StaticResource ScrollBarTrackBorderThickness}"
+                         Converter="{StaticResource ThicknessToSelectiveThicknessConverter}"
+                         ConverterParameter="{StaticResource ScrollBarSeparatorBorderFactors}" />
+              </Border.BorderThickness>
+            </Border>
             <ScrollBar Name="PART_VerticalScrollbar"
                        Orientation="Vertical"
                        Grid.Column="2"
                        Grid.Row="1"
-                       Background="{TemplateBinding ScrollBar.Background}"
-                       BorderBrush="{TemplateBinding ScrollBar.BorderBrush}"
-                       BorderThickness="{TemplateBinding ScrollBar.BorderThickness}"
+                       Background="{DynamicResource ScrollBarTrackBrush}"
+                       BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                       BorderThickness="1"
                        AllowAutoHide="{TemplateBinding ScrollBar.AllowAutoHide}"
                        Width="{DynamicResource ScrollBarSize}" />
 
@@ -601,9 +601,9 @@
               <ScrollBar Name="PART_HorizontalScrollbar"
                          Grid.Column="1"
                          Orientation="Horizontal"
-                         Background="{TemplateBinding ScrollBar.Background}"
-                         BorderBrush="{TemplateBinding ScrollBar.BorderBrush}"
-                         BorderThickness="{TemplateBinding ScrollBar.BorderThickness}"
+                         Background="{DynamicResource ScrollBarTrackBrush}"
+                         BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                         BorderThickness="1"
                          AllowAutoHide="{TemplateBinding ScrollBar.AllowAutoHide}"
                          Height="{DynamicResource ScrollBarSize}" />
             </Grid>

--- a/src/MacOS.Avalonia.Theme/Controls/Menu.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/Menu.axaml
@@ -191,9 +191,7 @@
                       HorizontalAlignment="Stretch"
                       BoxShadow="{DynamicResource PopupShadow}"
                       CornerRadius="{DynamicResource LayoutCornerRadius}">
-                <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}"
-                              BorderThickness="0"
-                              Background="Transparent">
+                <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}">
                   <ItemsPresenter Name="PART_ItemsPresenter"
                                   ItemsPanel="{TemplateBinding ItemsPanel}"
                                   Margin="{DynamicResource MenuFlyoutScrollerMargin}"

--- a/src/MacOS.Avalonia.Theme/Controls/ScrollViewer.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/ScrollViewer.axaml
@@ -23,10 +23,6 @@
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ScrollViewer}" TargetType="ScrollViewer">
-    <Setter Property="Background" Value="{DynamicResource ScrollBarTrackBrush}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ScrollBarTrackBorderBrush}" />
-    <Setter Property="BorderThickness" Value="1" />
-
     <Setter Property="Template">
       <ControlTemplate>
         <Grid ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
@@ -50,25 +46,27 @@
                      Grid.Row="1"
                      Grid.Column="0" Grid.ColumnSpan="2"
                      Orientation="Horizontal"
-                     Background="{TemplateBinding Background}"
-                     BorderBrush="{TemplateBinding BorderBrush}"
-                     BorderThickness="{TemplateBinding BorderThickness}" />
+                     Background="{DynamicResource ScrollBarTrackBrush}"
+                     BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                     BorderThickness="1" />
           <ScrollBar Name="PART_VerticalScrollBar"
                      Grid.Row="0" Grid.RowSpan="2"
                      Grid.Column="1"
                      Orientation="Vertical"
-                     Background="{TemplateBinding Background}"
-                     BorderBrush="{TemplateBinding BorderBrush}"
-                     BorderThickness="{TemplateBinding BorderThickness}" />
+                     Background="{DynamicResource ScrollBarTrackBrush}"
+                     BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                     BorderThickness="1" />
           <Border Name="PART_ScrollBarsSeparator"
                   Grid.Row="1"
                   Grid.Column="1"
-                  Background="{TemplateBinding Background}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness, 
-                    Converter={StaticResource ThicknessToSelectiveThicknessConverter}, 
-                    ConverterParameter={StaticResource ScrollBarSeparatorBorderFactors}}"
+                  Background="{DynamicResource ScrollBarTrackBrush}"
+                  BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
                   Opacity="0">
+            <Border.BorderThickness>
+              <Binding Source="{StaticResource ScrollBarTrackBorderThickness}"
+                       Converter="{StaticResource ThicknessToSelectiveThicknessConverter}"
+                       ConverterParameter="{StaticResource ScrollBarSeparatorBorderFactors}" />
+            </Border.BorderThickness>
             <Border.Transitions>
               <Transitions>
                 <DoubleTransition Property="Opacity" Duration="0:0:0.1" />
@@ -80,6 +78,23 @@
     </Setter>
 
 
+    <Style Selector="^.MacOS_TransparentTrack">
+      <Style
+        Selector="^ /template/ Border#PART_ScrollBarsSeparator">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style
+        Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style
+        Selector="^ /template/ ScrollBar#PART_HorizontalScrollBar">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+    </Style>
     <Style Selector="^[AllowAutoHide=False]">
       <Style Selector="^ /template/ Border#PART_ScrollBarsSeparator">
         <Setter Property="Opacity" Value="1" />

--- a/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
@@ -88,7 +88,6 @@
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ScrollViewer.AllowAutoHide" Value="False" />
-    <Setter Property="ScrollViewer.BorderThickness" Value="0" />
     <Setter Property="Template">
       <ControlTemplate>
         <DataValidationErrors>
@@ -116,7 +115,6 @@
                              Margin="2 2 3 1 ">
                     <ScrollViewer Name="PART_ScrollViewer"
                                   Margin="0 0 -4 0"
-                                  BorderThickness="{TemplateBinding (ScrollViewer.BorderThickness)}"
                                   HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                                   VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
                                   IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"

--- a/src/MacOS.Avalonia.Theme/Controls/TreeView.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/TreeView.axaml
@@ -4,7 +4,7 @@
   <ResourceDictionary.MergedDictionaries>
     <ResourceInclude Source="/Accents/ThemeResources.axaml" />
   </ResourceDictionary.MergedDictionaries>
-  
+
   <Design.PreviewWith>
     <Border Padding="20">
       <StackPanel Spacing="20">
@@ -28,7 +28,8 @@
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Border BorderBrush="{TemplateBinding BorderBrush}"
+        <Border Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="{TemplateBinding CornerRadius}">
           <ScrollViewer


### PR DESCRIPTION
Repurposing the ScrollViewer Background and Border properties for setting the look of the scrollbars wasn't a good idea, as it affects components with embedded ScrollViewer in unexpected ways that would be hard to override with styling on the consumer-side 