### PR TITLE
Fix intermittent unresponsiveness of TextBox scrolling

### DIFF
--- a/src/MacOS.Avalonia.Theme/Controls/ScrollViewer.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/ScrollViewer.axaml
@@ -23,12 +23,14 @@
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ScrollViewer}" TargetType="ScrollViewer">
+    <Setter Property="Background" Value="Transparent" />
     <Setter Property="Template">
       <ControlTemplate>
         <Grid ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
           <ScrollContentPresenter Name="PART_ContentPresenter"
                                   Grid.Row="0" Grid.RowSpan="2"
                                   Grid.Column="0" Grid.ColumnSpan="2"
+                                  Background="{TemplateBinding Background}"
                                   HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
                                   VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
                                   HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"


### PR DESCRIPTION
The multiline `TextBox` didn't seem to respond to scrolling very reliably. 
 
Turns out `ScrollContentPresenter` requires a default background colour (just `Transparent` is fine), otherwise it cannot receive pointer events, and scrolling will not work while the pointer is over areas of whitespace between the text. 