### PR TITLE
Fix the context menu on TextBox

### DIFF
--- a/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
@@ -31,6 +31,25 @@
     </ThemeVariantScope>
   </Design.PreviewWith>
 
+  <MenuFlyout x:Key="DefaultTextBoxContextFlyout">
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
+              IsEnabled="{Binding $parent[TextBox].CanCut}" InputGesture="{x:Static TextBox.CutGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
+              IsEnabled="{Binding $parent[TextBox].CanCopy}" InputGesture="{x:Static TextBox.CopyGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
+              IsEnabled="{Binding $parent[TextBox].CanPaste}" InputGesture="{x:Static TextBox.PasteGesture}" />
+  </MenuFlyout>
+  <MenuFlyout x:Key="HorizontalTextBoxContextFlyout"
+              FlyoutPresenterTheme="{StaticResource HorizontalMenuFlyoutPresenter}"
+              ItemContainerTheme="{StaticResource HorizontalMenuItem}">
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
+              IsEnabled="{Binding $parent[TextBox].CanCut}" IsVisible="{Binding $parent[TextBox].CanCut}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
+              IsEnabled="{Binding $parent[TextBox].CanCopy}" IsVisible="{Binding $parent[TextBox].CanCopy}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
+              IsEnabled="{Binding $parent[TextBox].CanPaste}" />
+  </MenuFlyout>
+
   <ControlTheme x:Key="FluentTextBoxButton" TargetType="Button">
     <Setter Property="Focusable" Value="False" />
     <Setter Property="Padding" Value="0" />
@@ -90,6 +109,8 @@
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
+    <Setter Property="ContextFlyout"
+            Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
     <Setter Property="ScrollViewer.AllowAutoHide" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>


### PR DESCRIPTION
The right-click menu shows up now.
![image](https://github.com/user-attachments/assets/b7dba138-a7a2-47b4-8f62-49d17fc98b98)

The TextBox should not really loose focus when its popup is open, but that is not handled by the theme.