### PR TITLE
Remove styling-dependance on the presence of a window at the root

### DIFF
--- a/src/MacOS.Avalonia.Theme/Accents/Styles.axaml
+++ b/src/MacOS.Avalonia.Theme/Accents/Styles.axaml
@@ -1,6 +1,11 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+  <!-- FontFamily should be inherited from Window normally. Adding this for RDM where the views are embedded into the native app without a Window -->
+  <Style Selector="TextBox">
+    <Setter Property="FontFamily" Value="{StaticResource MacOsThemeFontFamily}" />
+  </Style>
+
   <Style Selector="Menu.MacOS_Theme_MenuOpensAbove > MenuItem > Border > Panel > Popup">
     <Setter Property="Placement" Value="TopEdgeAlignedLeft" />
     <Setter Property="VerticalOffset" Value="{DynamicResource MenuPopupAboveVerticalOffset}" />

--- a/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
+++ b/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
@@ -200,6 +200,7 @@
 
 
   <!-- TODO: Appkit buttons have DD at the bottom, EE at the top & fading -> try sub-pixel rendering (UseLayoutRounding) (s. `default button issues.psd` ... -->
+  <FontFamily x:Key="MacOsThemeFontFamily">Helvetica Neue, Segoe UI, SF Pro, sans-serif</FontFamily>
 
   <LinearGradientBrush x:Key="ControlBackgroundRecessedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
     <GradientStop Offset="0" Color="{DynamicResource ControlBorderLowColor}" />

--- a/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
+++ b/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
@@ -200,7 +200,7 @@
 
 
   <!-- TODO: Appkit buttons have DD at the bottom, EE at the top & fading -> try sub-pixel rendering (UseLayoutRounding) (s. `default button issues.psd` ... -->
-  <FontFamily x:Key="MacOsThemeFontFamily">Helvetica Neue, Segoe UI, SF Pro, sans-serif</FontFamily>
+  <FontFamily x:Key="MacOsThemeFontFamily">Inter, Helvetica Neue, Segoe UI, SF Pro, sans-serif</FontFamily>
 
   <LinearGradientBrush x:Key="ControlBackgroundRecessedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
     <GradientStop Offset="0" Color="{DynamicResource ControlBorderLowColor}" />

--- a/src/MacOS.Avalonia.Theme/Controls/Button.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/Button.axaml
@@ -39,27 +39,30 @@
       <Setter Property="Background">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource ControlBackgroundAccentRaisedBrush}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource ControlBackgroundHighBrush}" />
+            <Binding Source="{StaticResource ControlBackgroundAccentRaisedBrush}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>
       <Setter Property="Foreground">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource ForegroundHighBrush}" />
+            <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>
       <Setter Property="BorderBrush">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource ButtonBorderAccentBrush}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource ControlBorderRaisedBrush}" />
+            <Binding Source="{StaticResource ButtonBorderAccentBrush}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>

--- a/src/MacOS.Avalonia.Theme/Controls/CheckBox.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/CheckBox.axaml
@@ -64,9 +64,10 @@
                     Stretch="Fill">
                 <Path.Fill>
                   <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-                    <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
+                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                             Converter="{x:Static BoolConverters.Not}" />
                     <Binding Source="{StaticResource ControlForegroundAccentInactiveHighBrush}" />
+                    <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
                   </MultiBinding>
                 </Path.Fill>
               </Path>
@@ -79,9 +80,10 @@
                          Stretch="Uniform">
                 <Rectangle.Fill>
                   <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-                    <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
+                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                             Converter="{x:Static BoolConverters.Not}" />
                     <Binding Source="{StaticResource ControlForegroundAccentInactiveHighBrush}" />
+                    <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
                   </MultiBinding>
                 </Rectangle.Fill>
               </Rectangle>
@@ -112,9 +114,10 @@
       <Setter Property="Background">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource ControlBackgroundAccentRaisedBrush}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource ControlBackgroundHighBrush}" />
+            <Binding Source="{StaticResource ControlBackgroundAccentRaisedBrush}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>
@@ -122,9 +125,10 @@
         <Setter Property="BorderBrush">
           <Setter.Value>
             <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-              <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-              <Binding Source="{StaticResource ControlBorderAccentBrush}" />
+              <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                       Converter="{x:Static BoolConverters.Not}" />
               <Binding Source="{StaticResource ControlBorderBrush}" />
+              <Binding Source="{StaticResource ControlBorderAccentBrush}" />
             </MultiBinding>
           </Setter.Value>
         </Setter>
@@ -138,9 +142,10 @@
       <Setter Property="Background">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource ControlBackgroundAccentRaisedBrush}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource ControlBackgroundHighBrush}" />
+            <Binding Source="{StaticResource ControlBackgroundAccentRaisedBrush}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>
@@ -148,9 +153,10 @@
         <Setter Property="BorderBrush">
           <Setter.Value>
             <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-              <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-              <Binding Source="{StaticResource ControlBorderAccentBrush}" />
+              <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                       Converter="{x:Static BoolConverters.Not}" />
               <Binding Source="{StaticResource ControlBorderBrush}" />
+              <Binding Source="{StaticResource ControlBorderAccentBrush}" />
             </MultiBinding>
           </Setter.Value>
         </Setter>

--- a/src/MacOS.Avalonia.Theme/Controls/ComboBox.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/ComboBox.axaml
@@ -37,18 +37,20 @@
     <Setter Property="Background">
       <Setter.Value>
         <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-          <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-          <Binding Source="{StaticResource ControlBackgroundAccentRaisedBrush}" />
+          <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                   Converter="{x:Static BoolConverters.Not}" />
           <Binding Source="{StaticResource ControlBackgroundHighBrush}" />
+          <Binding Source="{StaticResource ControlBackgroundAccentRaisedBrush}" />
         </MultiBinding>
       </Setter.Value>
     </Setter>
     <Setter Property="BorderBrush">
       <Setter.Value>
         <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-          <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-          <Binding Source="{StaticResource ControlBorderAccentBrush}" />
+          <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                   Converter="{x:Static BoolConverters.Not}" />
           <Binding Source="{StaticResource ControlBorderBrush}" />
+          <Binding Source="{StaticResource ControlBorderAccentBrush}" />
         </MultiBinding>
       </Setter.Value>
     </Setter>
@@ -138,9 +140,10 @@
                         Stretch="Uniform">
                     <Path.Fill>
                       <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-                        <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
+                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                                 Converter="{x:Static BoolConverters.Not}" />
                         <Binding Source="{StaticResource ControlForegroundAccentInactiveHighBrush}" />
+                        <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
                       </MultiBinding>
                     </Path.Fill>
                   </Path>
@@ -152,9 +155,10 @@
                         Stretch="Uniform">
                     <Path.Fill>
                       <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-                        <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
+                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                                 Converter="{x:Static BoolConverters.Not}" />
                         <Binding Source="{StaticResource ControlForegroundAccentInactiveHighBrush}" />
+                        <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
                       </MultiBinding>
                     </Path.Fill>
                     <Path.RenderTransform>

--- a/src/MacOS.Avalonia.Theme/Controls/DataGrid.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/DataGrid.axaml
@@ -103,12 +103,14 @@
     <Setter Property="Foreground">
       <Setter.Value>
         <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-          <MultiBinding Converter="{x:Static BoolConverters.And}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGridRow}" Path="IsSelected" />
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
+          <MultiBinding Converter="{x:Static BoolConverters.Or}">
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGridRow}" Path="IsSelected"
+                     Converter="{x:Static BoolConverters.Not}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
           </MultiBinding>
-          <Binding Source="{StaticResource DataGridForegroundSelectedBrush}" />
           <Binding Source="{StaticResource ForegroundHighBrush}" />
+          <Binding Source="{StaticResource DataGridForegroundSelectedBrush}" />
         </MultiBinding>
       </Setter.Value>
     </Setter>
@@ -414,9 +416,10 @@
       <Setter Property="Background">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource DataGridItemBackgroundSelected}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource SelectionInActiveWindow}" />
+            <Binding Source="{StaticResource DataGridItemBackgroundSelected}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>

--- a/src/MacOS.Avalonia.Theme/Controls/TreeViewItem.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/TreeViewItem.axaml
@@ -127,9 +127,10 @@
       <Setter Property="Background">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource TreeViewItemBackgroundSelected}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource SelectionInActiveWindow}" />
+            <Binding Source="{StaticResource TreeViewItemBackgroundSelected}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>
@@ -139,9 +140,10 @@
       <Setter Property="Foreground">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource TreeViewItemForegroundSelected}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource ForegroundHighBrush}" />
+            <Binding Source="{StaticResource TreeViewItemForegroundSelected}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>
@@ -150,9 +152,10 @@
       <Setter Property="Foreground">
         <Setter.Value>
           <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
-            <Binding Source="{StaticResource TreeViewItemForegroundSelected}" />
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                     Converter="{x:Static BoolConverters.Not}" />
             <Binding Source="{StaticResource ForegroundHighBrush}" />
+            <Binding Source="{StaticResource TreeViewItemForegroundSelected}" />
           </MultiBinding>
         </Setter.Value>
       </Setter>

--- a/src/MacOS.Avalonia.Theme/Controls/Window.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/Window.axaml
@@ -1,0 +1,32 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <ControlTheme x:Key="{x:Type Window}" TargetType="Window">
+    <Setter Property="Background" Value="{DynamicResource SystemRegionBrush}" />
+    <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
+    <Setter Property="TopLevel.SystemBarColor" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+    <Setter Property="FontFamily" Value="{StaticResource MacOsThemeFontFamily}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel>
+          <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+          <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+          <Panel Background="Transparent" Margin="{TemplateBinding WindowDecorationMargin}" />
+          <VisualLayerManager>
+            <VisualLayerManager.ChromeOverlayLayer>
+              <TitleBar />
+            </VisualLayerManager.ChromeOverlayLayer>
+            <ContentPresenter Name="PART_ContentPresenter"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              Content="{TemplateBinding Content}"
+                              Margin="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+          </VisualLayerManager>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/MacOS.Avalonia.Theme/Controls/_index.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/_index.axaml
@@ -22,5 +22,6 @@
     <MergeResourceInclude Source="ToolTip.axaml" />
     <MergeResourceInclude Source="TreeView.axaml" />
     <MergeResourceInclude Source="TreeViewItem.axaml" />
+    <MergeResourceInclude Source="Window.axaml" />
   </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>


### PR DESCRIPTION
In RDM, currently the main consumer of this MacOS theme, Avalonia views are embedded into a native app, by-passing the typical structure of an Avalonia app where all controls have a _Window_ as their ancestor. 

This PR removes the reliance on the presence of a Window at the root by:

- Setting an explicit font not only on `Window` (overriding Fluent's font settings) _but also_ on `TextBlock`, since in RDM's setup inheritance from the Window doesn't work
- Changing all styling conditional on the Window state, to default to the assumption that the window is active, if no Window is found. This breaks the mechanism for indicating wether the window is active or not for RDM, but keeps it intact for normal apps using the theme. 

Perhaps we can find a way to pass the native window state into a custom property at some point ...   