### PR TITLE
Fix white on white text in DataGrid

### DIFF
--- a/src/MacOS.Avalonia.Theme/Controls/DataGrid.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/DataGrid.axaml
@@ -102,15 +102,20 @@
     <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
     <Setter Property="Foreground">
       <Setter.Value>
-        <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-          <MultiBinding Converter="{x:Static BoolConverters.Or}">
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGridRow}" Path="IsSelected"
-                     Converter="{x:Static BoolConverters.Not}" />
-            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
-                     Converter="{x:Static BoolConverters.Not}" />
+        <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}" ConverterParameter="Foreground White">
+          <MultiBinding Converter="{x:Static BoolConverters.And}">
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGridRow}" Path="IsSelected" />
+            <MultiBinding Converter="{x:Static BoolConverters.Or}">
+              <MultiBinding Converter="{StaticResource IsUnsetConverter}">
+                <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" />
+              </MultiBinding>
+              <MultiBinding Converter="{StaticResource IsExplicitlyTrueConverter}">
+                <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive" />
+              </MultiBinding>
+            </MultiBinding>
           </MultiBinding>
-          <Binding Source="{StaticResource ForegroundHighBrush}" />
           <Binding Source="{StaticResource DataGridForegroundSelectedBrush}" />
+          <Binding Source="{StaticResource ForegroundHighBrush}" />
         </MultiBinding>
       </Setter.Value>
     </Setter>

--- a/src/MacOS.Avalonia.Theme/Converters/IsExplicitlyTrueConverter.cs
+++ b/src/MacOS.Avalonia.Theme/Converters/IsExplicitlyTrueConverter.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace MacOS.Avalonia.Theme.Converters;
+
+/// <summary>
+///   Takes a _single_ input and returns a boolean based on whether the input is a boolean and true.
+/// </summary>
+/// <param name="value">Any property that may or may not exist</param>
+/// <returns>True if the input resolves to true, else False</returns>
+/// <remarks>
+///   This Converter can be used to check for a property when the source may not even exist. It needs to be a
+///   MultiValueConverter,
+///   because Avalonia will not call a normal converter if the input value is `unset`.
+///   Having this converter is useful, because Avalonia's AND and OR converters will return 'unset' if any of the inputs
+///   are unset, even when one of the inputs is a boolean and would be sufficient to verify the conjunction!
+/// </remarks>
+public class IsExplicitlyTrueConverter : IMultiValueConverter
+{
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    return values[0] is true;
+  }
+
+  public object ConvertBack(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    throw new NotImplementedException();
+  }
+}

--- a/src/MacOS.Avalonia.Theme/Converters/IsUnsetConverter.cs
+++ b/src/MacOS.Avalonia.Theme/Converters/IsUnsetConverter.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace MacOS.Avalonia.Theme.Converters;
+
+/// <summary>
+///   Takes a _single_ input and returns a boolean if it is unset.
+/// </summary>
+/// <param name="value">Any property or property source that may or may not exist</param>
+/// <returns>True if the input resolves to AvaloniaProperty.UnsetValue, else False</returns>
+/// <remarks>
+///   This Converter can be used to check for the presence of a control or property. It needs to be a MultiValueConverter,
+///   because Avalonia will not call a normal converter if the input value is `unset`.
+///   Having this converter is useful, because Avalonia's AND and OR converters will return 'unset' if any of the inputs
+///   are unset, even when one of the inputs is a boolean and would be sufficient to verify the conjunction!
+/// </remarks>
+public class IsUnsetConverter : IMultiValueConverter
+{
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    return values[0] == AvaloniaProperty.UnsetValue;
+  }
+
+  public object ConvertBack(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    throw new NotImplementedException();
+  }
+}

--- a/src/MacOS.Avalonia.Theme/Converters/_index.axaml
+++ b/src/MacOS.Avalonia.Theme/Converters/_index.axaml
@@ -7,6 +7,8 @@
   <converters:CharToMacOsPasswordCharConverter x:Key="CharToMacOsPasswordCharConverter" />
   <converters:RevealPasswordToFontSizeConverter x:Key="RevealPasswordToFontSizeConverter" />
   <converters:BooleanToChoiceConverter x:Key="BooleanToChoiceConverter" />
+  <converters:IsUnsetConverter x:Key="IsUnsetConverter" />
+  <converters:IsExplicitlyTrueConverter x:Key="IsExplicitlyTrueConverter" />
   <converters:ClassToChoiceConverter x:Key="ClassToChoiceConverter" />
   <converters:ColorToCssFillConverter x:Key="ColorToCssFillConverter" />
   <converters:ThicknessToSelectiveThicknessConverter x:Key="ThicknessToSelectiveThicknessConverter" />


### PR DESCRIPTION
The boolean logic governing the foreground colour of a DataGrid row (based on whether it's selected or not, and whether the parent window is active or not) broke for RDM where views embedded directly into the native app do not have a window ancestor. 

This solution seems rather convoluted, but it works around the fact that Avalonia AND/OR converters do return a boolean when any of the input unset (even if that input wouldn't need to be evaluated based on the other input). 

