### PR TITLE
Simplify dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/" # Root directory where the solution file is located
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "nuget"
-    directory: "/src/MacOS.Avalonia.Theme"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "nuget"
-    directory: "/samples/SampleApp"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Looking at the duplicate PRs raised by dependabot, it seems to find the .csproj files without specifying each individual project.