### PR TITLE
[DevExpress] Change fixed tab height to MinHeight

### DIFF
--- a/src/DevExpress.Avalonia.Theme/Controls/TabItem.axaml
+++ b/src/DevExpress.Avalonia.Theme/Controls/TabItem.axaml
@@ -101,7 +101,7 @@
                     BorderBrush="{DynamicResource TabItemBorderSelectedBrush}"
                     BorderThickness="0 2 0 0" />
             <Border Name="CenterContent" Grid.Row="1" Grid.Column="1"
-                    Height="25"
+                    MinHeight="25"
                     Padding="{DynamicResource TabItemHeaderPadding}">
               <Panel>
                 <TextBlock


### PR DESCRIPTION
Had some second thoughts on making tab height independent of fonts - hopefully with `MinHeight` there is wriggle room for different fonts' line heights not affecting the tab height, but tabs can still grow to accommodate non-standard content (like larger icons)