### PR TITLE
[MacOS Theme] Fix various Textbox issues

### DIFF
--- a/samples/SampleApp/App.axaml
+++ b/samples/SampleApp/App.axaml
@@ -4,8 +4,8 @@
 
   <Application.Styles>
     <!-- <FluentTheme /> -->
-    <!-- <StyleInclude Source="avares://MacOS.Avalonia.Theme/MacOSTheme.axaml" /> -->
-    <StyleInclude Source="avares://DevExpress.Avalonia.Theme/DevExpressTheme.axaml" />
+    <StyleInclude Source="avares://MacOS.Avalonia.Theme/MacOSTheme.axaml" />
+    <!-- <StyleInclude Source="avares://DevExpress.Avalonia.Theme/DevExpressTheme.axaml" /> -->
     <StyleInclude Source="/Styles.axaml" />
   </Application.Styles>
 </Application>

--- a/samples/SampleApp/DemoPages/TextBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/TextBoxDemo.axaml
@@ -33,6 +33,11 @@
         <TextBox Watermark="Disabled" IsEnabled="False" />
         <TextBox PasswordChar="*" Classes="revealPasswordButton">Reveal Password</TextBox>
         <TextBox PasswordChar="*" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
+        <TextBlock>Custom Height:</TextBlock>
+        <StackPanel Orientation="Horizontal">
+          <TextBox Watermark="Type here" Height="30" Width="250" VerticalContentAlignment="Center" />
+          <Button Content="..." Height="30" Width="30" />
+        </StackPanel>
       </StackPanel>
     </Border>
   </ScrollViewer>

--- a/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
+++ b/src/MacOS.Avalonia.Theme/Accents/ThemeResources.axaml
@@ -234,7 +234,7 @@
   <Thickness x:Key="BorderThickness">1</Thickness>
 
   <x:Double x:Key="ControlFontSize">13</x:Double>
-  <x:Double x:Key="PasswordHiddenFontSize">8</x:Double>
+  <x:Double x:Key="PasswordHiddenFontSize">11</x:Double>
 
   <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
 

--- a/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
@@ -7,7 +7,7 @@
 
   <Design.PreviewWith>
     <!-- <ThemeVariantScope RequestedThemeVariant="Dark"> -->
-    <Border Background="#f0f0f0"> 
+    <Border Background="#f0f0f0">
       <Border Background="{DynamicResource LayoutBackgroundLowBrush}">
         <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
           <TextBlock>Name:</TextBlock>
@@ -25,6 +25,11 @@
           <TextBox Watermark="Enter your name" IsEnabled="False" />
           <TextBox PasswordChar="•" Classes="revealPasswordButton">Reveal Password</TextBox>
           <TextBox PasswordChar="•" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
+          <TextBlock>Custom Height:</TextBlock>
+          <StackPanel Orientation="Horizontal">
+            <TextBox Watermark="Type here" Height="30" Width="250" VerticalContentAlignment="Center" />
+            <Button Content="..." Height="30" Width="30" />
+          </StackPanel>
         </StackPanel>
       </Border>
     </Border>
@@ -116,93 +121,94 @@
       <ControlTemplate>
         <DataValidationErrors>
           <Panel>
-            <Border Name="FocusBorderElement"
-                    CornerRadius="3"
-                    Padding="3">
-              <Border Name="PART_BorderElement"
-                      BorderThickness="1"
-                      BorderBrush="Transparent"
-                      BoxShadow="{DynamicResource TextBoxBorderShadows}"
-                      Background="{TemplateBinding Background}">
-                <Grid ColumnDefinitions="Auto,*,Auto">
-                  <ContentPresenter Name="PrefixContent"
-                                    Grid.Column="0"
-                                    Content="{TemplateBinding InnerLeftContent}"
-                                    Padding="3 2 3 1">
-                    <ContentPresenter.IsVisible>
-                      <Binding RelativeSource="{RelativeSource Self}" Path="Content"
-                               Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
-                    </ContentPresenter.IsVisible>
-                  </ContentPresenter>
-                  <DockPanel Name="PART_InnerDockPanel"
-                             Grid.Column="1"
-                             Margin="2 2 3 1 ">
-                    <ScrollViewer Name="PART_ScrollViewer"
-                                  Margin="0 0 -4 0"
-                                  HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                                  IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
-                                  AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                                  BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
-                      <Panel>
-                        <TextBlock Name="PART_Watermark"
-                                   Foreground="{DynamicResource ForegroundLowBrush}"
-                                   FontSize="{DynamicResource ControlFontSize}"
-                                   Text="{TemplateBinding Watermark}"
-                                   TextAlignment="{TemplateBinding TextAlignment}"
-                                   TextWrapping="{TemplateBinding TextWrapping}"
-                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                          <TextBlock.IsVisible>
-                            <MultiBinding Converter="{x:Static BoolConverters.And}">
-                              <Binding ElementName="PART_TextPresenter" Path="PreeditText"
-                                       Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                              <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
-                                       Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                            </MultiBinding>
-                          </TextBlock.IsVisible>
-                        </TextBlock>
-                        <TextPresenter Name="PART_TextPresenter"
-                                       Text="{TemplateBinding Text, Mode=TwoWay}"
-                                       CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                       CaretIndex="{TemplateBinding CaretIndex}"
-                                       SelectionStart="{TemplateBinding SelectionStart}"
-                                       SelectionEnd="{TemplateBinding SelectionEnd}"
-                                       TextAlignment="{TemplateBinding TextAlignment}"
-                                       TextWrapping="{TemplateBinding TextWrapping}"
-                                       LineHeight="{TemplateBinding LineHeight}"
-                                       LetterSpacing="{TemplateBinding LetterSpacing}"
-                                       RevealPassword="{TemplateBinding RevealPassword}"
-                                       SelectionBrush="{TemplateBinding SelectionBrush}"
-                                       SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                       CaretBrush="{TemplateBinding CaretBrush}"
-                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                       VerticalAlignment="Center">
-                          <TextPresenter.PasswordChar>
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
-                                     Converter="{StaticResource CharToMacOsPasswordCharConverter}" />
-                          </TextPresenter.PasswordChar>
-                        </TextPresenter>
-                      </Panel>
-                      <ScrollViewer.Styles>
-                        <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
-                          <Setter Property="Cursor" Value="IBeam" />
-                        </Style>
-                      </ScrollViewer.Styles>
-                    </ScrollViewer>
-                  </DockPanel>
-                  <ContentPresenter Name="SuffixContent"
-                                    Grid.Column="2"
-                                    Padding="3 2 3 1"
-                                    Content="{TemplateBinding InnerRightContent}">
-                    <ContentPresenter.IsVisible>
-                      <Binding RelativeSource="{RelativeSource Self}" Path="Content"
-                               Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
-                    </ContentPresenter.IsVisible>
-                  </ContentPresenter>
-                </Grid>
-              </Border>
+            <Border Name="PART_BorderElement"
+                    Height="{TemplateBinding Height}"
+                    BorderThickness="1"
+                    BorderBrush="Transparent"
+                    BoxShadow="{DynamicResource TextBoxBorderShadows}"
+                    Background="{TemplateBinding Background}">
+              <Grid ColumnDefinitions="Auto,*,Auto">
+                <ContentPresenter Name="PrefixContent"
+                                  Grid.Column="0"
+                                  Content="{TemplateBinding InnerLeftContent}"
+                                  Padding="3 2 3 1">
+                  <ContentPresenter.IsVisible>
+                    <Binding RelativeSource="{RelativeSource Self}" Path="Content"
+                             Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
+                  </ContentPresenter.IsVisible>
+                </ContentPresenter>
+                <DockPanel Name="PART_InnerDockPanel"
+                           Grid.Column="1"
+                           Margin="2 2 3 1 ">
+                  <ScrollViewer Name="PART_ScrollViewer"
+                                Margin="0 0 -4 0"
+                                HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                                IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                                AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+                                BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+                    <Panel>
+                      <TextBlock Name="PART_Watermark"
+                                 Foreground="{DynamicResource ForegroundLowBrush}"
+                                 FontSize="{DynamicResource ControlFontSize}"
+                                 Text="{TemplateBinding Watermark}"
+                                 TextAlignment="{TemplateBinding TextAlignment}"
+                                 TextWrapping="{TemplateBinding TextWrapping}"
+                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                        <TextBlock.IsVisible>
+                          <MultiBinding Converter="{x:Static BoolConverters.And}">
+                            <Binding ElementName="PART_TextPresenter" Path="PreeditText"
+                                     Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
+                                     Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                          </MultiBinding>
+                        </TextBlock.IsVisible>
+                      </TextBlock>
+                      <TextPresenter Name="PART_TextPresenter"
+                                     Text="{TemplateBinding Text, Mode=TwoWay}"
+                                     CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                     CaretIndex="{TemplateBinding CaretIndex}"
+                                     SelectionStart="{TemplateBinding SelectionStart}"
+                                     SelectionEnd="{TemplateBinding SelectionEnd}"
+                                     TextAlignment="{TemplateBinding TextAlignment}"
+                                     TextWrapping="{TemplateBinding TextWrapping}"
+                                     LineHeight="{TemplateBinding LineHeight}"
+                                     LetterSpacing="{TemplateBinding LetterSpacing}"
+                                     RevealPassword="{TemplateBinding RevealPassword}"
+                                     SelectionBrush="{TemplateBinding SelectionBrush}"
+                                     SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                     CaretBrush="{TemplateBinding CaretBrush}"
+                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                     VerticalAlignment="Center">
+                        <TextPresenter.PasswordChar>
+                          <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
+                                   Converter="{StaticResource CharToMacOsPasswordCharConverter}" />
+                        </TextPresenter.PasswordChar>
+                      </TextPresenter>
+                    </Panel>
+                    <ScrollViewer.Styles>
+                      <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                        <Setter Property="Cursor" Value="IBeam" />
+                      </Style>
+                    </ScrollViewer.Styles>
+                  </ScrollViewer>
+                </DockPanel>
+                <ContentPresenter Name="SuffixContent"
+                                  Grid.Column="2"
+                                  Padding="3 2 3 1"
+                                  Content="{TemplateBinding InnerRightContent}">
+                  <ContentPresenter.IsVisible>
+                    <Binding RelativeSource="{RelativeSource Self}" Path="Content"
+                             Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
+                  </ContentPresenter.IsVisible>
+                </ContentPresenter>
+              </Grid>
             </Border>
+            <Border Name="FocusBorderElement"
+                    Height="{TemplateBinding Height}"
+                    BorderThickness="3"
+                    CornerRadius="3" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>
@@ -219,11 +225,8 @@
 
     <!-- Focused State -->
     <Style Selector="^:focus">
-      <Style Selector="^ /template/ DockPanel#PART_InnerDockPanel">
-        <Setter Property="Margin" Value="2 1 3 0 " />
-      </Style>
       <Style Selector="^ /template/ Border#FocusBorderElement">
-        <Setter Property="Background" Value="{DynamicResource TextBoxBorderFocusBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderFocusBrush}" />
       </Style>
     </Style>
 

--- a/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
@@ -6,29 +6,29 @@
   </ResourceDictionary.MergedDictionaries>
 
   <Design.PreviewWith>
-    <ThemeVariantScope RequestedThemeVariant="Dark">
-      <Border Background="#212121">
-        <Border Background="{DynamicResource LayoutBackgroundLowBrush}">
-          <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
-            <TextBlock>Name:</TextBlock>
-            <TextBox Watermark="Enter your name">MyServer</TextBox>
-            <TextBlock>Password:</TextBlock>
-            <TextBox PasswordChar="*" Watermark="Enter your password" />
-            <TextBlock>Notes:</TextBlock>
-            <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" />
-            <TextBox InnerLeftContent="http://" />
-            <TextBox InnerRightContent=".com" />
-            <TextBox
-              InnerLeftContent="http://"
-              InnerRightContent=".com" />
-            <TextBox Classes="clearButton">With 'Clear' button</TextBox>
-            <TextBox Watermark="Enter your name" IsEnabled="False" />
-            <TextBox PasswordChar="•" Classes="revealPasswordButton">Reveal Password</TextBox>
-            <TextBox PasswordChar="•" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
-          </StackPanel>
-        </Border>
+    <!-- <ThemeVariantScope RequestedThemeVariant="Dark"> -->
+    <Border Background="#f0f0f0"> 
+      <Border Background="{DynamicResource LayoutBackgroundLowBrush}">
+        <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
+          <TextBlock>Name:</TextBlock>
+          <TextBox Watermark="Enter your name">MyServer</TextBox>
+          <TextBlock>Password:</TextBlock>
+          <TextBox PasswordChar="*" Watermark="Enter your password" />
+          <TextBlock>Notes:</TextBlock>
+          <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" />
+          <TextBox InnerLeftContent="http://" />
+          <TextBox InnerRightContent=".com" />
+          <TextBox
+            InnerLeftContent="http://"
+            InnerRightContent=".com" />
+          <TextBox Classes="clearButton">With 'Clear' button</TextBox>
+          <TextBox Watermark="Enter your name" IsEnabled="False" />
+          <TextBox PasswordChar="•" Classes="revealPasswordButton">Reveal Password</TextBox>
+          <TextBox PasswordChar="•" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
+        </StackPanel>
       </Border>
-    </ThemeVariantScope>
+    </Border>
+    <!-- </ThemeVariantScope> -->
   </Design.PreviewWith>
 
   <MenuFlyout x:Key="DefaultTextBoxContextFlyout">


### PR DESCRIPTION
- Updates the fontsize for the hidden-password character, which after the font change in #63 looked too small:

  ![image](https://github.com/user-attachments/assets/6027766c-0696-4c07-90f5-44f900e22b32) 
  ![image](https://github.com/user-attachments/assets/fd557ad9-39a2-49cd-bbb4-f8e56423f199)

- Fixed the issue where setting the height of a TextBox always resulted in an apparent height 6 pixels less, because the focus highlight was taken into account.
  - Changing the way the focus border is created also fixed the tiny layout jumps when focussing a TextBox 
