### PR TITLE
[DevExpress] Tweak TabControl 

### DIFF
--- a/src/DevExpress.Avalonia.Theme/Accents/ThemeResources.axaml
+++ b/src/DevExpress.Avalonia.Theme/Accents/ThemeResources.axaml
@@ -32,8 +32,8 @@
   <SolidColorBrush x:Key="TabItemPointerOverBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.02" />
   <SolidColorBrush x:Key="TabItemBorderSelectedBrush" Color="{StaticResource SystemAccentColor}" />
 
-  <Thickness x:Key="TabItemHeaderPadding">10 0</Thickness>
-  <Thickness x:Key="FirstTabItemHeaderPadding">6 0 10 0</Thickness>
+  <Thickness x:Key="TabItemHeaderPadding">4 0</Thickness>
+  <Thickness x:Key="FirstTabItemHeaderPadding">6 0 4 0</Thickness>
 
 
 </ResourceDictionary>

--- a/src/DevExpress.Avalonia.Theme/Controls/TabControl.axaml
+++ b/src/DevExpress.Avalonia.Theme/Controls/TabControl.axaml
@@ -42,12 +42,14 @@
                   ColumnDefinitions="Auto, *">
               <ItemsPresenter Name="PART_ItemsPresenter"
                               Grid.Column="0"
+                              VerticalAlignment="Bottom"
                               ItemsPanel="{TemplateBinding ItemsPanel}" />
               <Border Name="CardBorderBeyondTheTabs"
                       Grid.Column="1"
                       HorizontalAlignment="Stretch"
                       VerticalAlignment="Bottom"
                       BorderBrush="{TemplateBinding BorderBrush}"
+                      Margin="7 0 0 0"
                       BorderThickness="0 0 0 1" />
             </Grid>
             <ContentPresenter Name="PART_SelectedContentHost"

--- a/src/DevExpress.Avalonia.Theme/Controls/TabItem.axaml
+++ b/src/DevExpress.Avalonia.Theme/Controls/TabItem.axaml
@@ -237,7 +237,7 @@
       <Style Selector="^ /template/ Border#BottomBorder">
         <Setter Property="IsVisible" Value="False" />
       </Style>
-      <Style Selector="^ /template/ Border#TopBorderSelected">
+      <Style Selector="^:focus /template/ Border#TopBorderSelected">
         <Setter Property="IsVisible" Value="True" />
       </Style>
     </Style>

--- a/src/DevExpress.Avalonia.Theme/Controls/TabItem.axaml
+++ b/src/DevExpress.Avalonia.Theme/Controls/TabItem.axaml
@@ -80,7 +80,16 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="1 0 0 0 " />
+                    BorderThickness="1 0 0 0 ">
+              <Border.IsVisible>
+                <MultiBinding Converter="{StaticResource TabBorderVisibilityConverter}"
+                              ConverterParameter="LeftBorder">
+                  <Binding Path="$parent[TabItem]" />
+                  <Binding Path="$parent[TabControl]" />
+                  <Binding Path="$parent[TabControl].SelectedIndex" />
+                </MultiBinding>
+              </Border.IsVisible>
+            </Border>
             <Border Name="FirstTabLeftBorder"
                     Grid.Row="1" Grid.Column="0"
                     Grid.RowSpan="2"
@@ -128,7 +137,16 @@
                     HorizontalAlignment="Left"
                     VerticalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="0 0 1 0 " />
+                    BorderThickness="0 0 1 0 ">
+              <Border.IsVisible>
+                <MultiBinding Converter="{StaticResource TabBorderVisibilityConverter}"
+                              ConverterParameter="RightBorder">
+                  <Binding Path="$parent[TabItem]" />
+                  <Binding Path="$parent[TabControl]" />
+                  <Binding Path="$parent[TabControl].SelectedIndex" />
+                </MultiBinding>
+              </Border.IsVisible>
+            </Border>
             <Border Name="BottomLeftCorner"
                     Grid.Row="2" Grid.Column="0"
                     Width="4"

--- a/src/DevExpress.Avalonia.Theme/Controls/TabItem.axaml
+++ b/src/DevExpress.Avalonia.Theme/Controls/TabItem.axaml
@@ -36,47 +36,47 @@
         <Border
           Name="PART_LayoutRoot"
           Background="Transparent"
-          Margin="0 0 -9 0">
-          <Grid RowDefinitions="5, *, 5" ColumnDefinitions="9, *, 9">
+          Margin="0 0 -7 0">
+          <Grid RowDefinitions="4, *, 4" ColumnDefinitions="7, *, 7">
             <Border Name="PointerOverBackground" Grid.Row="0" Grid.Column="0"
                     Grid.RowSpan="3" Grid.ColumnSpan="3"
                     Background="Transparent"
-                    CornerRadius="5 5 0 0"
-                    Margin="5 0 5 0" />
+                    CornerRadius="4 4 0 0"
+                    Margin="4 0 4 0" />
             <Border Name="TopLeftCorner"
                     Grid.Row="0" Grid.Column="0"
-                    Width="5"
-                    Height="5"
+                    Width="4"
+                    Height="4"
                     HorizontalAlignment="Right"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="1 1 0 0"
-                    CornerRadius="5 0 0 0 " />
+                    CornerRadius="4 0 0 0 " />
             <Border Name="FirstTabTopLeftCorner"
                     Grid.Row="0" Grid.Column="0"
                     IsVisible="False"
-                    Width="9"
-                    Height="5"
+                    Width="7"
+                    Height="4"
                     HorizontalAlignment="Right"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="1 1 0 0"
-                    CornerRadius="5 0 0 0 " />
+                    CornerRadius="4 0 0 0 " />
             <Border Name="TopBorder"
                     Grid.Row="0" Grid.Column="1"
-                    Height="5"
+                    Height="4"
                     HorizontalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="0 1 0 0" />
             <Border Name="TopRightCorner"
                     Grid.Row="0" Grid.Column="2"
-                    Width="5"
-                    Height="5"
+                    Width="4"
+                    Height="4"
                     HorizontalAlignment="Left"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="0 1 1 0"
-                    CornerRadius="0 5 0 0 " />
+                    CornerRadius="0 4 0 0 " />
             <Border Name="LeftBorder"
                     Grid.Row="1" Grid.Column="0"
-                    Width="5"
+                    Width="4"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
@@ -85,7 +85,7 @@
                     Grid.Row="1" Grid.Column="0"
                     Grid.RowSpan="2"
                     IsVisible="False"
-                    Width="9"
+                    Width="7"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
@@ -96,17 +96,17 @@
                     IsVisible="False"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
-                    CornerRadius="5 5 0 0"
-                    Margin="5 0 5 0"
+                    CornerRadius="4 4 0 0"
+                    Margin="4 0 4 0"
                     BorderBrush="{DynamicResource TabItemBorderSelectedBrush}"
                     BorderThickness="0 2 0 0" />
             <Border Name="CenterContent" Grid.Row="1" Grid.Column="1"
-                    MinHeight="25"
+                    MinHeight="20"
                     Padding="{DynamicResource TabItemHeaderPadding}">
               <Panel>
                 <TextBlock
                   Name="ReserveWidthForSelectedTabText"
-                  FontSize="14"
+                  FontSize="13"
                   FontWeight="Bold"
                   Foreground="Transparent"
                   Background="Transparent"
@@ -115,7 +115,7 @@
                   Text="{TemplateBinding Header}" />
                 <ContentPresenter
                   Name="PART_ContentPresenter"
-                  FontSize="13"
+                  FontSize="12"
                   HorizontalAlignment="Left"
                   VerticalAlignment="Center"
                   Content="{TemplateBinding Header}"
@@ -124,20 +124,20 @@
             </Border>
             <Border Name="RightBorder"
                     Grid.Row="1" Grid.Column="2"
-                    Width="5"
+                    Width="4"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="0 0 1 0 " />
             <Border Name="BottomLeftCorner"
                     Grid.Row="2" Grid.Column="0"
-                    Width="5"
-                    Height="5"
+                    Width="4"
+                    Height="4"
                     HorizontalAlignment="Left"
                     Background="Transparent"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="0 0 1 1   "
-                    CornerRadius="0 0 5 0 ">
+                    CornerRadius="0 0 4 0 ">
               <Border.IsVisible>
                 <MultiBinding Converter="{StaticResource TabBorderVisibilityConverter}"
                               ConverterParameter="BottomLeftCorner">
@@ -149,7 +149,7 @@
             </Border>
             <Border Name="BottomLeftBorder"
                     Grid.Row="2" Grid.Column="0"
-                    Height="5"
+                    Height="4"
                     HorizontalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="0 0 0 1">
@@ -164,13 +164,13 @@
             </Border>
             <Border Name="BottomBorder"
                     Grid.Row="2" Grid.Column="1"
-                    Height="5"
+                    Height="4"
                     HorizontalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="0 0 0 1" />
             <Border Name="BottomRightBorder"
                     Grid.Row="2" Grid.Column="2"
-                    Height="5"
+                    Height="4"
                     HorizontalAlignment="Stretch"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="0 0 0 1">
@@ -185,12 +185,12 @@
             </Border>
             <Border Name="BottomRightCorner"
                     Grid.Row="2" Grid.Column="2"
-                    Width="5"
-                    Height="5"
+                    Width="4"
+                    Height="4"
                     HorizontalAlignment="Right"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="1 0 0 1"
-                    CornerRadius="0 0 0 5 ">
+                    CornerRadius="0 0 0 4 ">
               <Border.IsVisible>
                 <MultiBinding Converter="{StaticResource TabBorderVisibilityConverter}"
                               ConverterParameter="BottomRightCorner">
@@ -222,17 +222,17 @@
         <Setter Property="Padding" Value="{DynamicResource FirstTabItemHeaderPadding}" />
       </Style>
       <Style Selector="^ /template/ Border#TopBorderSelected">
-        <Setter Property="Margin" Value="1 0 5 0" />
+        <Setter Property="Margin" Value="1 0 4 0" />
       </Style>
       <Style Selector="^ /template/ Border#PointerOverBackground">
-        <Setter Property="Margin" Value="0 0 5 0" />
+        <Setter Property="Margin" Value="0 0 4 0" />
       </Style>
     </Style>
 
     <Style Selector="^:selected">
       <Setter Property="ZIndex" Value="2" />
       <Setter Property="FontWeight" Value="Bold" />
-      <Setter Property="FontSize" Value="14" />
+      <Setter Property="FontSize" Value="13" />
       <!-- Visibility of the tab border corners in the 9-slice grid is handled through TabBorderVisibilityConverter -->
       <Style Selector="^ /template/ Border#BottomBorder">
         <Setter Property="IsVisible" Value="False" />
@@ -284,7 +284,7 @@
     <Style Selector="^[TabStripPlacement=Right]">
       <Setter Property="HorizontalContentAlignment" Value="Right" />
       <Style Selector="^ /template/ Border#PART_LayoutRoot">
-        <Setter Property="Margin" Value="-9 0 0 0" />
+        <Setter Property="Margin" Value="-7 0 0 0" />
       </Style>
       <Style Selector="^ /template/ Border#TopLeftCorner">
         <Setter Property="BorderThickness" Value="0" />

--- a/src/DevExpress.Avalonia.Theme/Converters/TabBorderVisibilityConverter.cs
+++ b/src/DevExpress.Avalonia.Theme/Converters/TabBorderVisibilityConverter.cs
@@ -37,8 +37,14 @@ public class TabBorderVisibilityConverter : IMultiValueConverter
 
     switch (parameter)
     {
+      case "LeftBorder":
+        return !isFirstTab && (isLeftOfSelectedTab || isSelected);
+        break;
       case "BottomLeftCorner":
         return !isFirstTab && (isLeftOfSelectedTab || isSelected);
+        break;
+      case "RightBorder":
+        return isLastTab || isRightOfSelectedTab || isSelected;
         break;
       case "BottomRightCorner":
         return isLastTab || isRightOfSelectedTab || isSelected;


### PR DESCRIPTION
- Adjusting size to match actual DevExpress 
- Change the accent line to only show up when tab is focussed
- Some changes to avoid overlapping lines (on my Mac screen the overlapping line sections are perfectly aligned (as they should be in theory), but on Windows or certain screens they appear just offset enough to be noticeable when you look very closely)