### PR TITLE
Adjust MacOS TextBox Padding

### DIFF
--- a/samples/SampleApp/DemoPages/TextBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/TextBoxDemo.axaml
@@ -6,7 +6,7 @@
              x:Class="SampleApp.DemoPages.TextBoxDemo">
 
   <UserControl.Styles>
-    <Style Selector="TextBlock">
+    <Style Selector="TextBlock.Label">
       <Setter Property="Margin" Value="3 0 0 0" />
     </Style>
   </UserControl.Styles>
@@ -18,11 +18,11 @@
             CornerRadius="{DynamicResource LayoutCornerRadius}"
             Background="{DynamicResource LayoutBackgroundLowBrush}">
       <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
-        <TextBlock>Name:</TextBlock>
+        <TextBlock Classes="Label">Name:</TextBlock>
         <TextBox Watermark="Enter your name" />
-        <TextBlock>Password:</TextBlock>
+        <TextBlock Classes="Label">Password:</TextBlock>
         <TextBox PasswordChar="*" Watermark="Enter your password" />
-        <TextBlock>Notes:</TextBlock>
+        <TextBlock Classes="Label">Notes:</TextBlock>
         <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" />
         <TextBox InnerLeftContent="http://" />
         <TextBox InnerRightContent=".com" />
@@ -33,7 +33,7 @@
         <TextBox Watermark="Disabled" IsEnabled="False" />
         <TextBox PasswordChar="*" Classes="revealPasswordButton">Reveal Password</TextBox>
         <TextBox PasswordChar="*" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
-        <TextBlock>Custom Height:</TextBlock>
+        <TextBlock Classes="Label">Custom Height:</TextBlock>
         <StackPanel Orientation="Horizontal">
           <TextBox Watermark="Type here" Height="30" Width="250" VerticalContentAlignment="Center" />
           <Button Content="..." Height="30" Width="30" />

--- a/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
+++ b/src/MacOS.Avalonia.Theme/Controls/TextBox.axaml
@@ -11,7 +11,7 @@
       <Border Background="{DynamicResource LayoutBackgroundLowBrush}">
         <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
           <TextBlock>Name:</TextBlock>
-          <TextBox Watermark="Enter your name">MyServer</TextBox>
+          <TextBox Watermark="Enter your name">Anna</TextBox>
           <TextBlock>Password:</TextBlock>
           <TextBox PasswordChar="*" Watermark="Enter your password" />
           <TextBlock>Notes:</TextBlock>
@@ -120,13 +120,15 @@
     <Setter Property="Template">
       <ControlTemplate>
         <DataValidationErrors>
-          <Panel>
+          <Border Padding="3">
+            <Panel>
             <Border Name="PART_BorderElement"
                     Height="{TemplateBinding Height}"
                     BorderThickness="1"
                     BorderBrush="Transparent"
                     BoxShadow="{DynamicResource TextBoxBorderShadows}"
-                    Background="{TemplateBinding Background}">
+                    Background="{TemplateBinding Background}"
+                    Padding="2 0 2 0 ">
               <Grid ColumnDefinitions="Auto,*,Auto">
                 <ContentPresenter Name="PrefixContent"
                                   Grid.Column="0"
@@ -207,9 +209,11 @@
             </Border>
             <Border Name="FocusBorderElement"
                     Height="{TemplateBinding Height}"
+                    Margin="-3"
                     BorderThickness="3"
                     CornerRadius="3" />
-          </Panel>
+            </Panel>
+          </Border>
         </DataValidationErrors>
       </ControlTemplate>
     </Setter>


### PR DESCRIPTION
#85 affected the TextBox padding and an earlier mistake within the local Demo styling lead to misleading results in the app. 

Both should be fixed with this