### PR TITLE
Fix typo in build-package workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -181,7 +181,7 @@ jobs:
         shell: pwsh
         run: |
           $DryRun = [System.Boolean]::Parse('${{ needs.preflight.outputs.dry-run }}')
-          $NugetPackage = (Get-Item ./package/*.nupkg) | Resolve-Path -Relative
+          $NugetPackages = (Get-Item ./package/*.nupkg) | Resolve-Path -Relative
 
           foreach ($NugetPackage in $NugetPackages) {
             $PushArgs = @(


### PR DESCRIPTION
The build-package workflow from #89 quietly fails in the publish step - I assume it's just this small typo.