### PR TITLE
Propagate default font to AccessText without parent Window

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/Styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/Styles.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <!-- FontFamily should be inherited from Window normally. Adding this for RDM where the views are embedded into the native app without a Window -->
-  <Style Selector="TextBlock">
+  <Style Selector="TextBlock, AccessText">
     <Setter Property="FontFamily" Value="{StaticResource DevExpressThemeFontFamily}" />
   </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/Styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/Styles.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <!-- FontFamily should be inherited from Window normally. Adding this for RDM where the views are embedded into the native app without a Window -->
-  <Style Selector="TextBlock">
+  <Style Selector="TextBlock, AccessText">
     <Setter Property="FontFamily" Value="{StaticResource MacOsThemeFontFamily}" />
   </Style>
 


### PR DESCRIPTION
This fixes spacing issues in RDM, where the embedded views do not have a parent Window and therefore don't inherit the default font. This applies the work-around used for `TextBlock` to `AccessText` also.