### PR TITLE
[DevExpress] Move RDM styles.windows into the theme

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/Styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/Styles.axaml
@@ -5,4 +5,47 @@
   <Style Selector="TextBlock, AccessText">
     <Setter Property="FontFamily" Value="{StaticResource DevExpressThemeFontFamily}" />
   </Style>
+
+  <Style Selector="TextBlock">
+    <Setter Property="FontSize" Value="12" />
+  </Style>
+
+  <Style Selector="TextBlock.SectionTitle">
+    <Setter Property="FontWeight" Value="Bold" />
+    <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style Selector="CheckBox">
+    <Setter Property="MinHeight" Value="1" />
+    <Setter Property="Height" Value="30" />
+    <Setter Property="Padding" Value="5 5" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+  </Style>
+
+  <Style Selector="AutoCompleteBox">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="MinHeight" Value="1" />
+    <Setter Property="Padding" Value="10 3" />
+  </Style>
+
+  <Style Selector="AutoCompleteBox ListBoxItem">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="MinHeight" Value="1" />
+    <Setter Property="Height" Value="26" />
+    <Setter Property="Padding" Value="10 2" />
+  </Style>
+
+  <Style Selector="DataGrid">
+    <Setter Property="RowHeight" Value="22" />
+    <Setter Property="ColumnHeaderHeight" Value="22" />
+  </Style>
+
+  <Style Selector="DataGridColumnHeader">
+    <Setter Property="Background" Value="{DynamicResource MainControlBackground}" />
+    <Setter Property="MinHeight" Value="22" />
+  </Style>
+
+  <Style Selector="DataGridRow:nth-child(even)">
+    <Setter Property="Background" Value="{DynamicResource DataGridRowAlternatingBackgroundBrush}" />
+  </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -77,8 +77,8 @@
 
   <SolidColorBrush x:Key="ComboBoxDropDownBorderBrushTransparent" Color="{DynamicResource ForegroundColor}"
                    Opacity="0.28" />
-  <Thickness x:Key="ComboBoxPadding">5,0,5,0</Thickness>
-  <x:Double x:Key="ComboBoxMinHeight">23</x:Double>
+  <Thickness x:Key="ComboBoxPadding">10,0,10,0</Thickness>
+  <x:Double x:Key="ComboBoxMinHeight">24</x:Double>
   <BoxShadows x:Key="ComboBoxDropDownShadow"> 0 3 7 0 #30000000</BoxShadows>
 
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Button.axaml
@@ -27,7 +27,7 @@
     <Setter Property="Padding" Value="5 0 5 0 " />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="FontSize" Value="11" />
+    <Setter Property="FontSize" Value="12" />
     <Setter Property="FontWeight" Value="Light" />
     <Setter Property="Template">
       <ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBox.axaml
@@ -38,7 +38,7 @@
     <Setter Property="Padding" Value="{DynamicResource ComboBoxPadding}" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="MaxDropDownHeight" Value="504" />
-    <Setter Property="FontSize" Value="11" />
+    <Setter Property="FontSize" Value="12" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBoxItem.axaml
@@ -25,17 +25,17 @@
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ComboBoxItem}" TargetType="ComboBoxItem">
-    <Setter Property="FontSize" Value="11" />
+    <Setter Property="FontSize" Value="12" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
-    <Setter Property="Padding" Value="8 0 5 0" />
+    <Setter Property="Padding" Value="10 3 " />
     <Setter Property="CornerRadius" Value="3" />
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="LayoutRoot"
                 Background="Transparent"
-                MinHeight="27"
+                MinHeight="24"
                 CornerRadius="{TemplateBinding CornerRadius}"
                 Padding="0 7 0 5">
           <StackPanel Orientation="Horizontal">

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -115,7 +115,7 @@
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="MinHeight" Value="26" />
     <Setter Property="MinWidth" Value="26" />
-    <Setter Property="Padding" Value="5 0 5 0" />
+    <Setter Property="Padding" Value="10 3" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ContextFlyout"
@@ -173,6 +173,7 @@
                     <Panel>
                       <TextBlock Name="PART_Watermark"
                                  Opacity="0.5"
+                                 FontSize="{DynamicResource ControlFontSize}"
                                  Text="{TemplateBinding Watermark}"
                                  TextAlignment="{TemplateBinding TextAlignment}"
                                  TextWrapping="{TemplateBinding TextWrapping}"


### PR DESCRIPTION
Some of the styling numbers conflicted with the current ones in the theme - but since they were written looking directly on how things are rendered on Windows, they are probably more accurate than what I had measured on Mac, and they do look good, so I adopted all of them. 