### PR TITLE
[MacOS] Add default styling for text

### DIFF
--- a/samples/SampleApp/DemoPages/TextBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/TextBoxDemo.axaml
@@ -6,7 +6,7 @@
              x:Class="SampleApp.DemoPages.TextBoxDemo">
 
   <UserControl.Styles>
-    <Style Selector="TextBlock.Label">
+    <Style Selector="Label">
       <Setter Property="Margin" Value="3 0 0 0" />
     </Style>
   </UserControl.Styles>
@@ -18,11 +18,11 @@
             CornerRadius="{DynamicResource LayoutCornerRadius}"
             Background="{DynamicResource LayoutBackgroundLowBrush}">
       <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
-        <TextBlock Classes="Label">Name:</TextBlock>
+        <Label>_Name:</Label>
         <TextBox Watermark="Enter your name" />
-        <TextBlock Classes="Label">Password:</TextBlock>
+        <Label>Password:</Label>
         <TextBox PasswordChar="*" Watermark="Enter your password" />
-        <TextBlock Classes="Label">Notes:</TextBlock>
+        <Label>Notes:</Label>
         <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" />
         <TextBox InnerLeftContent="http://" />
         <TextBox InnerRightContent=".com" />

--- a/samples/SampleApp/DemoPages/ToolTipDemo.axaml
+++ b/samples/SampleApp/DemoPages/ToolTipDemo.axaml
@@ -17,7 +17,8 @@
         <ToolTip Opacity="1">Very long text content which should exceed the maximum with of the tooltip and wrap.</ToolTip>
         <ToolTip Opacity="1" HorizontalAlignment="Left">
           <StackPanel>
-            <TextBlock>Multi-line</TextBlock>
+            <TextBlock>Complex</TextBlock>
+            <Svg Path="/Assets/CopyUserNamePassword.svg" Width="16" />
             <TextBlock>ToolTip Content</TextBlock>
           </StackPanel>
         </ToolTip>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/Styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/Styles.axaml
@@ -1,11 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-  <!-- FontFamily should be inherited from Window normally. Adding this for RDM where the views are embedded into the native app without a Window -->
-  <Style Selector="TextBlock, AccessText">
-    <Setter Property="FontFamily" Value="{StaticResource MacOsThemeFontFamily}" />
-  </Style>
-
   <Style Selector="Menu.MacOS_Theme_MenuOpensAbove > MenuItem > Border > Panel > Popup">
     <Setter Property="Placement" Value="TopEdgeAlignedLeft" />
     <Setter Property="VerticalOffset" Value="{DynamicResource MenuPopupAboveVerticalOffset}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -247,6 +247,7 @@
 
   <Thickness x:Key="BorderThickness">1</Thickness>
 
+  <x:Double x:Key="DefaultFontSize">13</x:Double>
   <x:Double x:Key="ControlFontSize">13</x:Double>
   <x:Double x:Key="PasswordHiddenFontSize">11</x:Double>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EmbeddableControlRoot.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EmbeddableControlRoot.axaml
@@ -1,0 +1,26 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <ControlTheme x:Key="{x:Type EmbeddableControlRoot}" TargetType="EmbeddableControlRoot">
+    <Setter Property="Background" Value="{DynamicResource SystemRegionBrush}" />
+    <Setter Property="TopLevel.SystemBarColor" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="FontSize" Value="{DynamicResource DefaultFontSize}" />
+    <Setter Property="FontFamily" Value="{StaticResource MacOsThemeFontFamily}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel>
+          <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+          <Border Background="{TemplateBinding Background}">
+            <VisualLayerManager>
+              <ContentPresenter Name="PART_ContentPresenter"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                Content="{TemplateBinding Content}"
+                                Margin="{TemplateBinding Padding}" />
+            </VisualLayerManager>
+          </Border>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Window.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Window.axaml
@@ -5,8 +5,8 @@
     <Setter Property="Background" Value="{DynamicResource SystemRegionBrush}" />
     <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
     <Setter Property="TopLevel.SystemBarColor" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
-    <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-    <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="FontSize" Value="{DynamicResource DefaultFontSize}" />
     <Setter Property="FontFamily" Value="{StaticResource MacOsThemeFontFamily}" />
     <Setter Property="Template">
       <ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
@@ -9,6 +9,7 @@
     <MergeResourceInclude Source="ComboBoxItem.axaml" />
     <MergeResourceInclude Source="ContextMenu.axaml" />
     <MergeResourceInclude Source="DataGrid.axaml" />
+    <MergeResourceInclude Source="EmbeddableControlRoot.axaml" />
     <MergeResourceInclude Source="GridSplitter.axaml" />
     <MergeResourceInclude Source="Menu.axaml" />
     <MergeResourceInclude Source="MenuFlyoutPresenter.axaml" />


### PR DESCRIPTION
This sets the defaults for `FontSize` and `Foreground` in `Window`  (for normal stand-alone apps) and `EmbeddableControlRoot` (for scenarios like RDM). This way general text controls like `TextBlock` and `Label` simply inherit the styles and don't have to be explicitly styled. 

Note: explicitly styling `TextBlock` causes massive problems, because there are so many dynamically created `TextBlock`s in controls' `ContentPresenters` (i.e. they only get created if the content provided is a simple string, and therefore they are not a part of the logical tree and do not receive the local template styling anymore if there is a general `TextBlock` rule, and cannot easily overwritten then - except with hard-coded styles rather than template bindings ... 