### PR TITLE
Fix ComboBox button centering 

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -131,8 +131,14 @@
                             Focusable="False"
                             IsChecked="{TemplateBinding IsDropDownOpen,
                                                       Mode=TwoWay}">
-                <Grid RowDefinitions="Auto, Auto" Margin="2 -0.5 0 0">
-                  <Path Grid.Row="0" Width="9"
+                <StackPanel VerticalAlignment="Center" Spacing="2">
+                  <StackPanel.RenderTransform>
+                    <TransformGroup>
+                      <TranslateTransform X="1" />
+                      <TranslateTransform Y="-1" />
+                    </TransformGroup>
+                  </StackPanel.RenderTransform>
+                  <Path Width="9"
                         Height="4.5"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
@@ -147,7 +153,7 @@
                       </MultiBinding>
                     </Path.Fill>
                   </Path>
-                  <Path Grid.Row="1" Width="9"
+                  <Path Width="9"
                         Height="4.5"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
@@ -162,14 +168,10 @@
                       </MultiBinding>
                     </Path.Fill>
                     <Path.RenderTransform>
-                      <TransformGroup>
-                        <!-- <RotateTransform Angle="180" CenterY="0.8" CenterX="-0.8" /> -->
-                        <ScaleTransform ScaleY="-1" />
-                        <TranslateTransform Y="1.5" />
-                      </TransformGroup>
+                      <ScaleTransform ScaleY="-1" />
                     </Path.RenderTransform>
                   </Path>
-                </Grid>
+                </StackPanel>
               </ToggleButton>
             </Grid>
           </Border>


### PR DESCRIPTION
The ComboBox button exhibits strange variation in how it's rendered - here two screenshots, Retina display & external monitor:

![image](https://github.com/user-attachments/assets/2db593d8-8599-4dfd-84de-d43267411607)

Since the NumericUpDown control (using the same chevrons, but centered by RenderTransforms instead of Margins) is rendered more consistently, I'm trying to replicate that approach for the ComboBox