### PR TITLE
[DevExpress] Fix missing icon path for CheckBox chevron

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/Icons.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/Icons.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+  <StreamGeometry x:Key="ChevronPath">M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z</StreamGeometry>
   <StreamGeometry x:Key="CheckMarkPath">M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z</StreamGeometry>
   <StreamGeometry x:Key="CheckMarkPathFat">M5.5,9.6l-3.8-3.8c-.4-.4-1,.6-1.4,1-.4.4-1.4,1-1,1.4l5.5,5.5c.4.4,1,.4,1.4,0L18.2,1.7c.4-.4-.6-1-1-1.4-.4-.4-1-1.4-1.4-1L5.5,9.6Z</StreamGeometry>
   <StreamGeometry x:Key="CheckMarkIndeterminatePath">M1536 1536v-1024h-1024v1024h1024z</StreamGeometry>


### PR DESCRIPTION
Fixing a bug introduced in #110, where I started pulling icon paths into a separate file, but forgot to add the chevron path 